### PR TITLE
slint-demos: fix checksum and fix missing branch in src_uri

### DIFF
--- a/recipes-example/slint-demos/slint-demos_git.bb
+++ b/recipes-example/slint-demos/slint-demos_git.bb
@@ -1,8 +1,8 @@
 inherit cargo
 
-SRC_URI = "git://github.com/slint-ui/slint.git;protocol=https;rev=master"
+SRC_URI = "git://github.com/slint-ui/slint.git;protocol=https;branch=master;rev=master"
 SRC_URI += "file://0001-WIP-Use-a-patched-gettext-to-avoid-cross-compiling-g.patch"
-LIC_FILES_CHKSUM = "file://LICENSE.md;md5=4f9282cc0add078ee5638e65bb55c77c"
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=de1f7e3f6c26ccc1b87ed67735db968f"
 
 SUMMARY = "Various Rust-based demos of Slint packaged up in /usr/bin"
 DESCRIPTION = "This recipe builds various Slint demos such as the energy monitor \


### PR DESCRIPTION
Fix license file checksum that is breaking the Yocto build and add branch information for SRC_URI to fix Yocto warning.