### PR TITLE
slint-demos_git.bb: update license checksum

### DIFF
--- a/recipes-example/slint-demos/slint-demos_git.bb
+++ b/recipes-example/slint-demos/slint-demos_git.bb
@@ -2,7 +2,7 @@ inherit cargo
 
 SRC_URI = "git://github.com/slint-ui/slint.git;protocol=https;branch=master;rev=master"
 SRC_URI += "file://0001-WIP-v1-2-0-Use-a-patched-gettext-to-avoid-cross-compiling-g.patch"
-LIC_FILES_CHKSUM = "file://LICENSE.md;md5=de1f7e3f6c26ccc1b87ed67735db968f"
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=c12ffea0eacb376c3ba8c0601fe78d5d"
 
 SUMMARY = "Various Rust-based demos of Slint packaged up in /usr/bin"
 DESCRIPTION = "This recipe builds various Slint demos such as the energy monitor \


### PR DESCRIPTION
The recipe pulls the latest master from Git. LICENSE.md changed in https://github.com/slint-ui/slint/pull/3284.
```
ERROR: slint-demos-git-r0 do_populate_lic: QA Issue: slint-demos: The LIC_FILES_CHKSUM does not match for file://LICENSE.md;md5=de1f7e3f6c26ccc1b87ed67735db968f
slint-demos: The new md5 checksum is c12ffea0eacb376c3ba8c0601fe78d5d
slint-demos: Here is the selected license text:
vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->

# Slint License

You can use Slint under ***any*** of the following licenses, at your choice:

1. [Royalty-free license](LICENSES/LicenseRef-Slint-Royalty-free-1.1.md),
2. [GNU GPLv3](LICENSES/GPL-3.0-only.txt),
3. [Paid license](https://slint.dev/pricing.html).

Third party licenses listed in the `LICENSES` folder also apply to parts of the product.

Contact us at [info@slint.dev](mailto:info@slint.dev) if you have any questions regarding licensing.
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```