### PR TITLE
Fix of the hash md5 of the license file that is breaking the Yocto Project build

### DIFF
--- a/recipes-slint/slint/slint-cpp_git.bb
+++ b/recipes-slint/slint/slint-cpp_git.bb
@@ -4,7 +4,7 @@ require recipes-slint/slint/slint-cpp-v2.inc
 # from 1.1.0 release
 SRC_URI += "file://0001-WIP-git-Use-a-patched-gettext-to-avoid-cross-compiling-g.patch"
 
-LIC_FILES_CHKSUM = "file://LICENSE.md;md5=47db5060638acc88cba176445dbd98b6"
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=f13bc9fc6013845c2405c20512c0d17b"
 SLINT_REV = "master"
 
 PV = "git-${SRCPV}"


### PR DESCRIPTION
I am using the Yocto Project (scarthgap) and building an image for a client's proof of concept (PoC) using Slint, compiling slint-cpp. The build broke due to the LICENSE.md file, which was recently updated and changed the file's MD5 hash.

```
ERROR: slint-cpp-native-git-AUTOINC+8faa22292e-r0 do_populate_lic: QA Issue: slint-cpp-native: The LIC_FILES_CHKSUM does not match for file://LICENSE.md;md5=47db5060638acc88cba176445dbd98b6
slint-cpp-native: The new md5 checksum is f13bc9fc6013845c2405c20512c0d17b
slint-cpp-native: Here is the selected license text:
vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0 -->

# Slint License

You can use Slint under ***any*** of the following licenses, at your choice:

1. Build proprietary desktop, mobile, or web applications for free with the [Royalty-free License](LICENSES/LicenseRef-Slint-Royalty-free-2.0.md),
2. Build open source embedded, desktop, mobile, or web applications for free with the [GNU GPLv3](LICENSES/GPL-3.0-only.txt),
3. Build proprietary embedded, desktop, mobile, or web applications with the [Paid license](LICENSES/LicenseRef-Slint-Software-3.0.md).

Third party licenses listed in the `LICENSES` folder also apply to parts of the product.

See the [Slint licensing options on the website](https://slint.dev/pricing.html) and the [Licensing FAQ](FAQ.md#licensing).
Contact us at [info@slint.dev](mailto:info@slint.dev) if you have any q