### PR TITLE
Convert LICENSE to SPDX GPL-3.0-only identifier

### DIFF
--- a/dynamic-layers/meta-st-openstlinux/recipes-samples/images/st-example-image-slint.bb
+++ b/dynamic-layers/meta-st-openstlinux/recipes-samples/images/st-example-image-slint.bb
@@ -1,5 +1,5 @@
 SUMMARY = "ST example of image based on Slint framework."
-LICENSE = "GPLv3|Slint-Commercial"
+LICENSE = "GPL-3.0-only | Slint-Commercial"
 
 include recipes-st/images/st-image.inc
 

--- a/dynamic-layers/meta-st-openstlinux/recipes-samples/packagegroups/packagegroup-framework-sample-slint.bb
+++ b/dynamic-layers/meta-st-openstlinux/recipes-samples/packagegroups/packagegroup-framework-sample-slint.bb
@@ -1,5 +1,5 @@
 SUMMARY = "Framework sample Slint components with linuxkms backend"
-LICENSE = "GPLv3|Slint-Commercial"
+LICENSE = "GPL-3.0-only | Slint-Commercial"
 
 inherit packagegroup features_check
 

--- a/recipes-example/slint-demos/slint-demos_git.bb
+++ b/recipes-example/slint-demos/slint-demos_git.bb
@@ -9,7 +9,7 @@ SUMMARY = "Various Rust-based demos of Slint packaged up in /usr/bin"
 DESCRIPTION = "This recipe builds various Slint demos such as the energy monitor \
 or the printer demo and installs the binaries into /usr/bin."
 HOMEPAGE = "https://slint.dev/"
-LICENSE = "GPLv3|Slint-Commercial"
+LICENSE = "GPL-3.0-only | Slint-Commercial"
 
 inherit slint_common
 

--- a/recipes-example/slint-hello-world/slint-hello-world_git.bb
+++ b/recipes-example/slint-hello-world/slint-hello-world_git.bb
@@ -5,7 +5,7 @@ SRC_URI = "git://github.com/slint-ui/slint-cpp-template.git;protocol=https;branc
 
 SUMMARY = "Work in progress recipe for Slint Hello World"
 HOMEPAGE = "https://github.com/slint-ui/slint"
-LICENSE = "GPLv3|Slint-Commercial"
+LICENSE = "GPL-3.0-only | Slint-Commercial"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=9e911597e678943cde54111f7518e299"
 
 S = "${WORKDIR}/git"

--- a/recipes-slint/slint/slint-cpp-v2.inc
+++ b/recipes-slint/slint/slint-cpp-v2.inc
@@ -9,7 +9,7 @@ crate from crates.io."
 HOMEPAGE = "https://github.com/slint-ui/slint"
 BUGTRACKER = "https://github.com/slint-ui/slint/issues"
 
-LICENSE = "GPLv3|Slint-Commercial"
+LICENSE = "GPL-3.0-only | Slint-Commercial"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=a71019dc9c240d7add35e9d036870929"
 
 inherit cmake


### PR DESCRIPTION
Replace non-SPDX "GPLv3|Slint-Commercial" with SPDX-compliant "GPL-3.0-only | Slint-Commercial" to fix license manifest errors in kirkstone and scarthgap builds.