### PR TITLE
Add Slint 1.14.0 and 1.14.1 releases

### DIFF
--- a/recipes-slint/slint/slint-cpp/0001-WIP-v-1-14-0-Use-a-patched-gettext-to-avoid-cross-compiling-g.patch
+++ b/recipes-slint/slint/slint-cpp/0001-WIP-v-1-14-0-Use-a-patched-gettext-to-avoid-cross-compiling-g.patch
@@ -1,0 +1,23 @@
+From 99551b8fe4096a3f060e6d8884ee3461250494a5 Mon Sep 17 00:00:00 2001
+From: Simon Hausmann <simon.hausmann@slint-ui.com>
+Date: Sun, 18 Jun 2023 11:35:07 +0200
+Subject: [PATCH] WIP: Use a patched gettext to avoid cross-compiling gettext
+ when building with Yocto
+
+---
+ Cargo.toml | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/Cargo.toml b/Cargo.toml
+index f6baf71a5..a0046c152 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -183,6 +183,9 @@ windows = { version = "0.62" }
+ windows-core = { version = "0.62.0" }
+
++[patch.crates-io]
++gettext-sys = { git = "https://github.com/slint-ui/gettext-rs", branch = "simon/fix-linux-detection" }
++
+ [profile.release]
+ lto = true
+ panic = "abort"

--- a/recipes-slint/slint/slint-cpp_1.14.0.bb
+++ b/recipes-slint/slint/slint-cpp_1.14.0.bb
@@ -1,0 +1,12 @@
+require recipes-slint/slint/slint-cpp-v2.inc
+
+# Either REMOVE or REPLACE this patch, but never change it, as it's also referenced
+# from other releases
+SRC_URI += "file://0001-WIP-v-1-14-0-Use-a-patched-gettext-to-avoid-cross-compiling-g.patch"
+
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=e3e11de4e6652abe8c9b2d74b416f33b"
+
+# v1.14.0 tag
+SLINT_REV = "0caf3b8114f992eed94e11ec0b08afe5d6a30c0a"
+
+EXTRA_OECMAKE:append = " -DSLINT_FEATURE_GETTEXT=ON"

--- a/recipes-slint/slint/slint-cpp_1.14.1.bb
+++ b/recipes-slint/slint/slint-cpp_1.14.1.bb
@@ -1,0 +1,12 @@
+require recipes-slint/slint/slint-cpp-v2.inc
+
+# Either REMOVE or REPLACE this patch, but never change it, as it's also referenced
+# from other releases
+SRC_URI += "file://0001-WIP-v-1-14-0-Use-a-patched-gettext-to-avoid-cross-compiling-g.patch"
+
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=e3e11de4e6652abe8c9b2d74b416f33b"
+
+# v1.14.1 tag
+SLINT_REV = "ce50ea806a9a1d512d30acab6f99c8a1d511505f"
+
+EXTRA_OECMAKE:append = " -DSLINT_FEATURE_GETTEXT=ON"


### PR DESCRIPTION
Add recipes for Slint v1.14.0 and v1.14.1 releases. Both versions use the same LICENSE.md checksum and gettext patch.