### PR TITLE
slint-demos, slint-cpp: depend on virtual/libgles2 not virtual/libgl

### DIFF
--- a/recipes-example/slint-demos/slint-demos/0001-WIP-v-1-14-0-Use-a-patched-gettext-to-avoid-cross-compiling-g.patch
+++ b/recipes-example/slint-demos/slint-demos/0001-WIP-v-1-14-0-Use-a-patched-gettext-to-avoid-cross-compiling-g.patch
@@ -11,13 +11,13 @@ Upstream-Status: Inappropriate [embedded specific]
  1 file changed, 3 insertions(+)
 
 diff --git a/Cargo.toml b/Cargo.toml
-index 184bc4d080..145e5987f1 100644
+index b2f6bb07c9..fc1fb48941 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -200,6 +200,9 @@ windows-core = { version = "0.62.0" }
- lyon_path = { version = "1.0", default-features = false }
- objc2 = { version = "0.6.3" }
-
+@@ -212,6 +212,9 @@ objc2 = { version = "0.6.3" }
+ # Not updated because of https://github.com/gluon-lang/lsp-types/issues/284
+ lsp-types = "0.95.0"
+ 
 +[patch.crates-io]
 +gettext-sys = { git = "https://github.com/slint-ui/gettext-rs", branch = "simon/fix-linux-detection" }
 +

--- a/recipes-example/slint-demos/slint-demos_git.bb
+++ b/recipes-example/slint-demos/slint-demos_git.bb
@@ -17,7 +17,7 @@ PV = "git-${SRCPV}"
 
 REQUIRED_DISTRO_FEATURES:append:class-target = "opengl"
 
-DEPENDS:append:class-target = " fontconfig libxkbcommon virtual/libgl"
+DEPENDS:append:class-target = " fontconfig libxkbcommon virtual/libgles2"
 DEPENDS:append:class-target = " clang-cross-${TARGET_ARCH} ca-certificates-native curl-native"
 DEPENDS:append:class-target = " libdrm virtual/egl virtual/libgbm seatd udev libinput"
 DEPENDS:append:class-target = " \

--- a/recipes-slint/slint/slint-cpp-v2.inc
+++ b/recipes-slint/slint/slint-cpp-v2.inc
@@ -19,7 +19,7 @@ inherit slint_common
 REQUIRED_DISTRO_FEATURES:append:class-target = "opengl"
 
 DEPENDS:append = " fontconfig"
-DEPENDS:append:class-target = " libxkbcommon virtual/libgl"
+DEPENDS:append:class-target = " libxkbcommon virtual/libgles2"
 RDEPENDS:${PN}:class-target += "xkeyboard-config"
 
 SLINT_REV ?= "master"

--- a/recipes-slint/slint/slint-cpp/0001-WIP-git-Use-a-patched-gettext-to-avoid-cross-compiling-g.patch
+++ b/recipes-slint/slint/slint-cpp/0001-WIP-git-Use-a-patched-gettext-to-avoid-cross-compiling-g.patch
@@ -11,13 +11,13 @@ Upstream-Status: Inappropriate [embedded specific]
  1 file changed, 3 insertions(+)
 
 diff --git a/Cargo.toml b/Cargo.toml
-index 184bc4d080..145e5987f1 100644
+index b2f6bb07c9..fc1fb48941 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -200,6 +200,9 @@ windows-core = { version = "0.62.0" }
- lyon_path = { version = "1.0", default-features = false }
- objc2 = { version = "0.6.3" }
-
+@@ -212,6 +212,9 @@ objc2 = { version = "0.6.3" }
+ # Not updated because of https://github.com/gluon-lang/lsp-types/issues/284
+ lsp-types = "0.95.0"
+ 
 +[patch.crates-io]
 +gettext-sys = { git = "https://github.com/slint-ui/gettext-rs", branch = "simon/fix-linux-detection" }
 +

--- a/scripts/ci_setup.sh
+++ b/scripts/ci_setup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -ex
 
-git clone -b scarthgap git://git.yoctoproject.org/poky
-git clone -b scarthgap git://git.openembedded.org/meta-openembedded
+git clone -b scarthgap https://git.yoctoproject.org/poky
+git clone -b scarthgap https://git.openembedded.org/meta-openembedded
 git clone -b master https://github.com/rust-embedded/meta-rust-bin.git
 git clone -b scarthgap https://github.com/kraj/meta-clang.git
 


### PR DESCRIPTION
Slint renders via GLES (femtovg/skia over EGL), so depend on GLES2 rather than desktop GL. On GLES-only vendor-GPU platforms virtual/libgl resolves to mesa and collides with the vendor blob on KHR/khrplatform.h.