### PR TITLE
Add Raspberry Pi 4 and 5 Slint demo images

### DIFF
--- a/.github/workflows/demo-images.yml
+++ b/.github/workflows/demo-images.yml
@@ -4,7 +4,7 @@ name: Demo Images
 # each into the rolling "demo-images" GitHub release, replacing the previous
 # asset in place. One script per device lives under scripts/demo-images/; add a
 # board by dropping in scripts/demo-images/<device>.sh and adding it to the
-# matrix below.
+# `device` choice input below. Each run builds the one device selected.
 #
 # The "demo-images" prerelease is expected to already exist; CI only clobbers
 # its assets (which needs the built-in GITHUB_TOKEN with contents: write).
@@ -19,6 +19,24 @@ name: Demo Images
 
 on:
   workflow_dispatch:
+    inputs:
+      device:
+        description: "Device to build the Slint demo image for"
+        type: choice
+        required: true
+        default: imx95-evk
+        options:
+          - imx95-evk
+          - rpi5
+          - rpi4
+
+# Only one demo-images build may run at a time: they share a single Hetzner
+# Volume for the sstate cache, and a Volume attaches to just one server. Queue
+# a new run behind the one in flight (cancel-in-progress: false) rather than
+# starting a doomed second build that can't get the volume.
+concurrency:
+  group: demo-images
+  cancel-in-progress: false
 
 jobs:
   prepare_env:
@@ -52,12 +70,6 @@ jobs:
     # A from-scratch vendor BSP build (no sstate mirror) runs past GitHub's
     # default 6h job limit; self-hosted runners honour a higher timeout-minutes.
     timeout-minutes: 600
-    strategy:
-      fail-fast: false
-      matrix:
-        device:
-          - imx95-evk
-
     steps:
       - uses: actions/checkout@v4
         with:
@@ -83,52 +95,112 @@ jobs:
           # OpenEmbedded's pseudo/bitbake rely on unprivileged user namespaces,
           # which Ubuntu restricts by default on recent releases.
           echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
-          useradd -m build
+          # Idempotent, in case the runner is ever reused across jobs.
+          id -u build &>/dev/null || useradd -m build
           echo "build ALL=(ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/build
           chown -R build:build ${{ runner.workspace }}
           # Persistent sstate cache on the attached Hetzner Volume. The runner
           # action attaches the volume as a raw block device but does NOT mount
           # it, so mount it ourselves -- otherwise the sstate dir would land on
-          # the ephemeral disk and every build would run cold. Format once, only
-          # if the volume has no filesystem yet (safe: it starts empty).
+          # the ephemeral disk and every build would run cold.
+          #
+          # A Hetzner Volume can only be attached to ONE server at a time, so if
+          # another demo-images build is already running it holds this volume and
+          # the attach/mount here fails. That MUST fail the job hard: we never
+          # fall back to an unmounted (ephemeral) sstate dir, which would run
+          # cold and, worse, could let two builds race the shared cache. Every
+          # branch below therefore exits non-zero rather than continuing.
           SSTATE_VOL=/dev/disk/by-id/scsi-0HC_Volume_106201634
           SSTATE_MNT=/mnt/HC_Volume_106201634
           if [ ! -b "$SSTATE_VOL" ]; then
-            echo "::error::sstate volume $SSTATE_VOL not attached"; lsblk; exit 1
+            echo "::error::sstate volume $SSTATE_VOL is not attached -- another build is likely holding it; failing."
+            lsblk; exit 1
           fi
+          # Format once, only if the volume has no filesystem yet (safe: it
+          # starts empty). Only mkfs when blkid clearly reports no filesystem.
           if ! sudo blkid "$SSTATE_VOL" >/dev/null 2>&1; then
             echo "Volume has no filesystem; creating ext4 (one-time)."
             sudo mkfs.ext4 -F -L sstate "$SSTATE_VOL"
           fi
           sudo mkdir -p "$SSTATE_MNT"
-          sudo mount "$SSTATE_VOL" "$SSTATE_MNT"
-          mountpoint -q "$SSTATE_MNT" || { echo "::error::failed to mount sstate volume"; lsblk; df -h; exit 1; }
+          # Idempotent: skip the mount if already mounted (reused runner).
+          if ! mountpoint -q "$SSTATE_MNT"; then
+            sudo mount "$SSTATE_VOL" "$SSTATE_MNT" || {
+              echo "::error::failed to mount sstate volume $SSTATE_VOL -- another build may be holding it; failing."
+              lsblk; df -h; exit 1
+            }
+          fi
+          # Belt and braces: refuse to proceed unless the mount really is backed
+          # by the sstate volume, so a build can never run against the ephemeral
+          # disk with a stale/empty cache.
+          if ! mountpoint -q "$SSTATE_MNT"; then
+            echo "::error::$SSTATE_MNT is not a mountpoint -- refusing to build without the sstate volume."
+            lsblk; df -h; exit 1
+          fi
+          mount_src=$(findmnt -no SOURCE --target "$SSTATE_MNT" || true)
+          if [ "$(readlink -f "$mount_src")" != "$(readlink -f "$SSTATE_VOL")" ]; then
+            echo "::error::$SSTATE_MNT is backed by '$mount_src', not the sstate volume $SSTATE_VOL; failing."
+            lsblk; df -h; exit 1
+          fi
           echo "sstate volume mounted:"; df -h "$SSTATE_MNT"
           # Create the sstate dir and hand it to the build user.
           sudo mkdir -p "$SSTATE_MNT/sstate-cache"
           sudo chown build:build "$SSTATE_MNT/sstate-cache"
-      - name: "build ${{ matrix.device }} demo image"
+      - name: "build ${{ inputs.device }} demo image"
         run: |
           SSTATE_DIR=/mnt/HC_Volume_106201634/sstate-cache
+          # Per-device build tree, so a reused runner never mixes one device's
+          # sources/ and build/ with another's.
+          WORK_ROOT=${{ runner.workspace }}/build-${{ inputs.device }}
           echo "sstate objects before build: $(find "$SSTATE_DIR" -name '*.tar.zst' 2>/dev/null | wc -l)"
           su - build -c "cd ${{ runner.workspace }}/meta-slint && \
-            ARTIFACT_DIR='${{ runner.workspace }}/meta-slint/artifacts' \
+            WORK_ROOT='${WORK_ROOT}' \
+            ARTIFACT_DIR='${WORK_ROOT}/artifacts' \
             SSTATE_DIR='${SSTATE_DIR}' \
-            meta-slint/scripts/demo-images/${{ matrix.device }}.sh"
+            meta-slint/scripts/demo-images/${{ inputs.device }}.sh"
           echo "sstate objects after build:  $(find "$SSTATE_DIR" -name '*.tar.zst' 2>/dev/null | wc -l)"
-      - name: "publish ${{ matrix.device }} image to the demo-images release"
+      - name: "publish ${{ inputs.device }} image to the demo-images release"
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          cd ${{ runner.workspace }}/meta-slint/artifacts
+          cd ${{ runner.workspace }}/build-${{ inputs.device }}/artifacts
           # Bundle the collected image files into a single, stably-named zip --
           # the same "<device>-demo-image.zip" you'd get by downloading the
           # workflow artifact from the browser. -0 (store) avoids re-compressing
           # the already-compressed .wic.zst. The stable name means --clobber
           # replaces the asset in place on each build (no accumulation).
-          zip -j -0 "${{ matrix.device }}-demo-image.zip" ./*
+          zip -j -0 "${{ inputs.device }}-demo-image.zip" ./*
           gh release upload demo-images --repo "${{ github.repository }}" --clobber \
-            "${{ matrix.device }}-demo-image.zip"
+            "${{ inputs.device }}-demo-image.zip"
+      - name: "prune stale sstate objects"
+        # Best-effort, and runs even if the build failed, to keep the shared
+        # Volume from growing unbounded. Never fail the job over pruning.
+        if: ${{ always() }}
+        continue-on-error: true
+        env:
+          # Override to tune; objects not used by a build in this many days go.
+          SSTATE_MAX_AGE_DAYS: "30"
+        run: |
+          SSTATE_DIR=/mnt/HC_Volume_106201634/sstate-cache
+          if ! mountpoint -q /mnt/HC_Volume_106201634; then
+            echo "sstate volume not mounted; nothing to prune"; exit 0
+          fi
+          before=$(find "$SSTATE_DIR" -name '*.tar.zst' 2>/dev/null | wc -l)
+          # Prune by access time: bitbake reads an object (and its .siginfo)
+          # when it restores it, so -atime tracks "least recently used". This
+          # relies on the volume being mounted with atime updates (ext4's
+          # default relatime -- do NOT mount it noatime, or LRU info is lost).
+          sudo find "$SSTATE_DIR" -type f -name '*.tar.zst'         -atime +"$SSTATE_MAX_AGE_DAYS" -delete
+          sudo find "$SSTATE_DIR" -type f -name '*.tar.zst.siginfo' -atime +"$SSTATE_MAX_AGE_DAYS" -delete
+          # Never keep Slint's own sstate: the slint-cpp/slint-demos recipes
+          # track master, so their objects are per-build churn and -- worse -- a
+          # matching hash could restore a stale (non-latest) build. Dropping them
+          # every run forces each image to rebuild Slint from current master.
+          # The glob matches both the .tar.zst objects and their .siginfo files.
+          sudo find "$SSTATE_DIR" -type f -name 'sstate:slint*' -delete
+          sudo find "$SSTATE_DIR" -mindepth 1 -type d -empty -delete 2>/dev/null || true
+          after=$(find "$SSTATE_DIR" -name '*.tar.zst' 2>/dev/null | wc -l)
+          echo "sstate objects: $before -> $after (dropped Slint + anything unused > ${SSTATE_MAX_AGE_DAYS} days)"
 
   delete-runner:
     name: Delete Runner

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -23,6 +23,8 @@ BBFILES_DYNAMIC += " \
     meta-rz-distro:${LAYERDIR}/dynamic-layers/meta-rz-distro/*/*/*.bbappend \
     freescale-distro:${LAYERDIR}/dynamic-layers/meta-freescale-distro/*/*/*.bb \
     freescale-distro:${LAYERDIR}/dynamic-layers/meta-freescale-distro/*/*/*.bbappend \
+    raspberrypi:${LAYERDIR}/dynamic-layers/meta-raspberrypi/*/*/*.bb \
+    raspberrypi:${LAYERDIR}/dynamic-layers/meta-raspberrypi/*/*/*.bbappend \
     "
 
 LICENSE_PATH += "${LAYERDIR}/custom-licenses"

--- a/dynamic-layers/meta-raspberrypi/recipes-example/slint-demos/slint-demos/slint-demos.service
+++ b/dynamic-layers/meta-raspberrypi/recipes-example/slint-demos/slint-demos/slint-demos.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Startup script to launch Slint demo(s) on startup
+
+[Service]
+ExecStart=/usr/bin/home-automation
+
+[Install]
+WantedBy=multi-user.target

--- a/dynamic-layers/meta-raspberrypi/recipes-example/slint-demos/slint-demos_%.bbappend
+++ b/dynamic-layers/meta-raspberrypi/recipes-example/slint-demos/slint-demos_%.bbappend
@@ -1,0 +1,13 @@
+inherit systemd
+
+SYSTEMD_AUTO_ENABLE = "enable"
+SYSTEMD_SERVICE:${PN} = "slint-demos.service"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+SRC_URI:append = " file://slint-demos.service"
+FILES:${PN} += "${systemd_unitdir}/system/slint-demos.service"
+
+do_install:append() {
+  install -d ${D}/${systemd_unitdir}/system
+  install -m 0644 ${WORKDIR}/slint-demos.service ${D}/${systemd_unitdir}/system
+}

--- a/dynamic-layers/meta-raspberrypi/recipes-graphics/images/rpi-image-slint-demos.bb
+++ b/dynamic-layers/meta-raspberrypi/recipes-graphics/images/rpi-image-slint-demos.bb
@@ -1,0 +1,18 @@
+SUMMARY = "A minimal image with the Slint demos, running on the Raspberry Pi via KMS/DRM"
+
+LICENSE = "MIT"
+
+inherit core-image
+
+IMAGE_FEATURES += "ssh-server-dropbear"
+
+CORE_IMAGE_BASE_INSTALL += " \
+    slint-demos \
+    liberation-fonts \
+"
+
+# Emit a compressed .wic plus its block map, so the workflow can publish an
+# image that is flashable directly with bmaptool. WKS_FILE is the SD-card
+# layout shipped by meta-raspberrypi (FAT boot partition + ext4 rootfs).
+IMAGE_FSTYPES = "wic.zst wic.bmap"
+WKS_FILE = "sdimage-raspberrypi.wks"

--- a/scripts/demo-images/rpi-common.sh
+++ b/scripts/demo-images/rpi-common.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Shared build steps for the Raspberry Pi Slint demo images.
+#
+# The per-Pi scripts (rpi4.sh, rpi5.sh) differ only in the target MACHINE;
+# everything else -- the poky/meta-* checkout, the layer set, the distro
+# features and the artifact collection -- is identical, so it lives here.
+# Source common.sh and this file, set MACHINE, then call slint_demo_build_rpi.
+#
+# meta-raspberrypi is a plain community layer, so we bootstrap by cloning poky
+# and the extra layers directly (no vendor manifest or EULA involved).
+#
+# Reads from the environment (defaults in parentheses):
+#   YOCTO_RELEASE  (scarthgap)   branch used for poky + the OE layers
+#   MACHINE        (required)    set by the caller, e.g. raspberrypi5
+#   DISTRO         (poky)
+#   IMAGE          (rpi-image-slint-demos)
+#   WORK_ROOT      ($PWD)        build tree is created here
+#   ARTIFACT_DIR   ($WORK_ROOT/artifacts)  flashable image copied here
+#   SSTATE_DIR     (unset)       set to a persistent path to reuse an sstate cache
+#   META_SLINT_DIR (required)    path to this meta-slint checkout
+
+slint_demo_build_rpi() {
+    local yocto_release="${YOCTO_RELEASE:-scarthgap}"
+    local machine="${MACHINE:?MACHINE must be set by the caller (e.g. raspberrypi5)}"
+    local distro="${DISTRO:-poky}"
+    local image="${IMAGE:-rpi-image-slint-demos}"
+    local meta_slint_dir="${META_SLINT_DIR:?META_SLINT_DIR must be set by the caller}"
+
+    local work_root="${WORK_ROOT:-$PWD}"
+    export ARTIFACT_DIR="${ARTIFACT_DIR:-$work_root/artifacts}"
+    mkdir -p "$work_root"
+    cd "$work_root"
+
+    slint_demo_ensure_git_identity
+
+    # --- Fetch poky and the layers (all community git, no manifest/EULA). ---
+    local src="$work_root/sources"
+    mkdir -p "$src"
+    _rpi_clone() {  # _rpi_clone <dir-name> <url> <branch>
+        local dir="$src/$1"
+        if [ ! -d "$dir" ]; then
+            git clone -b "$3" --single-branch "$2" "$dir"
+        fi
+    }
+    _rpi_clone poky              https://git.yoctoproject.org/poky              "$yocto_release"
+    _rpi_clone meta-openembedded https://git.openembedded.org/meta-openembedded "$yocto_release"
+    _rpi_clone meta-raspberrypi  https://git.yoctoproject.org/meta-raspberrypi  "$yocto_release"
+    _rpi_clone meta-clang        https://github.com/kraj/meta-clang.git         "$yocto_release"
+    # meta-rust-bin tracks master (no per-release branches).
+    if [ ! -d "$src/meta-rust-bin" ]; then
+        git clone https://github.com/rust-embedded/meta-rust-bin.git "$src/meta-rust-bin"
+    fi
+
+    # --- Initialise the build directory. ---
+    # oe-init-build-env references unset variables (BBSERVER, ...) and returns
+    # non-zero in places, so relax the shell's strict flags while sourcing it.
+    set +eu
+    source "$src/poky/oe-init-build-env" "$work_root/build"
+    set -eu
+
+    # --- Add the layers. Order matters for LAYERDEPENDS: meta-python before
+    # meta-networking, and meta-rust-bin before meta-slint. meta-raspberrypi
+    # depends on the meta-oe/python/multimedia/networking layers. ---
+    bitbake-layers add-layer \
+        "$src/meta-openembedded/meta-oe" \
+        "$src/meta-openembedded/meta-python" \
+        "$src/meta-openembedded/meta-multimedia" \
+        "$src/meta-openembedded/meta-networking" \
+        "$src/meta-raspberrypi" \
+        "$src/meta-clang" \
+        "$src/meta-rust-bin" \
+        "$meta_slint_dir"
+
+    # --- Machine + Slint + disk-conservation configuration. ---
+    echo "MACHINE = \"$machine\"" >> conf/local.conf
+    echo "DISTRO ?= \"$distro\"" >> conf/local.conf
+    # The Slint demos need an OpenGL-capable distro (KMS/DRM + GLES via Mesa's V3D).
+    echo 'DISTRO_FEATURES:append = " opengl"' >> conf/local.conf
+    # The Raspberry Pi WiFi firmware (linux-firmware-rpidistro), pulled in by the
+    # base image, carries the "synaptics-killswitch" license flag; accept it so the
+    # firmware is buildable instead of skipped.
+    echo 'LICENSE_FLAGS_ACCEPTED:append = " synaptics-killswitch"' >> conf/local.conf
+    slint_demo_configure_local_conf conf/local.conf
+
+    # Point sstate at a persistent cache (e.g. a mounted Hetzner Volume) when the
+    # workflow provides one; DL_DIR is deliberately left at its default so downloads
+    # stay ephemeral. A warm sstate restores most recipes without re-fetching.
+    if [ -n "${SSTATE_DIR:-}" ]; then
+        echo "SSTATE_DIR = \"$SSTATE_DIR\"" >> conf/local.conf
+    fi
+
+    # --- Build. ---
+    bitbake "$image"
+
+    # --- Collect the flashable image for the workflow to publish. ---
+    # Ship the compressed image plus its block map; bmaptool can flash the
+    # .wic.zst directly using the .bmap. Match by extension (OpenEmbedded adds a
+    # ".rootfs" infix), and restrict to regular files so OE's convenience
+    # symlinks don't duplicate the (large) image in the artifact.
+    local deploy="tmp/deploy/images/$machine"
+    local -a slint_demo_images
+    mapfile -t slint_demo_images < <(
+        find "$deploy" -maxdepth 1 -type f \( -name '*.wic.zst' -o -name '*.wic.bmap' \) | sort
+    )
+    slint_demo_collect_artifacts "${slint_demo_images[@]}"
+}

--- a/scripts/demo-images/rpi4.sh
+++ b/scripts/demo-images/rpi4.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Build the Slint demo image for the Raspberry Pi 4 Model B and collect the
+# flashable artifacts into $ARTIFACT_DIR for the workflow to publish.
+#
+# The shared Raspberry Pi build logic lives in rpi-common.sh; this script only
+# pins the target MACHINE. See rpi-common.sh for the overridable environment.
+#
+# raspberrypi4-64 is meta-raspberrypi's 64-bit machine for the Pi 4 (and 4B);
+# the Skia renderer needs a 64-bit, OpenGL-capable target.
+set -euo pipefail
+
+MACHINE="${MACHINE:-raspberrypi4-64}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# scripts/demo-images/<this> -> repo root is two levels up.
+META_SLINT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# shellcheck source=scripts/demo-images/common.sh
+. "$SCRIPT_DIR/common.sh"
+# shellcheck source=scripts/demo-images/rpi-common.sh
+. "$SCRIPT_DIR/rpi-common.sh"
+
+slint_demo_build_rpi

--- a/scripts/demo-images/rpi5.sh
+++ b/scripts/demo-images/rpi5.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Build the Slint demo image for the Raspberry Pi 5 and collect the flashable
+# artifacts into $ARTIFACT_DIR for the workflow to publish.
+#
+# The shared Raspberry Pi build logic lives in rpi-common.sh; this script only
+# pins the target MACHINE. See rpi-common.sh for the overridable environment.
+set -euo pipefail
+
+MACHINE="${MACHINE:-raspberrypi5}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# scripts/demo-images/<this> -> repo root is two levels up.
+META_SLINT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# shellcheck source=scripts/demo-images/common.sh
+. "$SCRIPT_DIR/common.sh"
+# shellcheck source=scripts/demo-images/rpi-common.sh
+. "$SCRIPT_DIR/rpi-common.sh"
+
+slint_demo_build_rpi


### PR DESCRIPTION
Build flashable Slint demo images for the Raspberry Pi 5 (raspberrypi5) and the Raspberry Pi 4 Model B (raspberrypi4-64), alongside the existing i.MX95 EVK. The two Pi boards share everything but the target MACHINE, so the common build steps -- poky/meta-* checkout, layer set, opengl distro feature, the synaptics-killswitch license flag, sstate wiring and artifact collection -- live in scripts/demo-images/rpi-common.sh, with rpi4.sh/rpi5.sh as thin wrappers that only pin the machine.

A new machine-independent image recipe (rpi-image-slint-demos) installs the Slint demos on top of core-image and emits a bmaptool-flashable .wic.zst plus .bmap; a slint-demos bbappend auto-starts the demo via systemd. The meta-raspberrypi dynamic layer is wired up in conf/layer.conf.

The workflow gains a workflow_dispatch 'device' choice input so each run builds one selected board, and reuses a persistent sstate cache on a Hetzner Volume. Because a Volume attaches to only one server at a time, builds are serialized with a concurrency group and the mount step hard-fails rather than ever building cold against the ephemeral disk. A prune step keeps the shared Volume bounded: it drops objects unused beyond 30 days and always discards Slint's own sstate so each image rebuilds Slint from current master.