### PR TITLE
Boot the Raspberry Pi demo images by running them on systemd

### DIFF
--- a/.github/workflows/demo-images.yml
+++ b/.github/workflows/demo-images.yml
@@ -46,6 +46,27 @@ jobs:
       label: ${{ steps.create-runner.outputs.label }}
       server_id: ${{ steps.create-runner.outputs.server_id }}
     steps:
+      - name: "wait for the sstate volume to detach from the previous build"
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HETZNER_API_KEY }}
+        run: |
+          # The concurrency group serializes runs, but a Hetzner server's
+          # deletion -- and therefore the detach of its attached volume --
+          # completes asynchronously, after the previous run's delete-runner job
+          # has already returned. If we create this run's server too soon, the
+          # create action fails to attach the shared sstate volume because the
+          # old server still holds it. Poll the volume until it is free.
+          vol=106201634
+          for i in $(seq 1 60); do
+            server=$(curl -fsSL -H "Authorization: Bearer $HCLOUD_TOKEN" \
+              "https://api.hetzner.cloud/v1/volumes/$vol" | jq -r '.volume.server // "null"')
+            if [ "$server" = "null" ]; then
+              echo "sstate volume $vol is free after $((i - 1)) poll(s)"; exit 0
+            fi
+            echo "sstate volume $vol still attached to server $server; waiting ($i/60)..."
+            sleep 10
+          done
+          echo "::error::timed out waiting for sstate volume $vol to detach"; exit 1
       - uses: Cyclenerd/hcloud-github-runner@v1
         id: create-runner
         with:
@@ -156,6 +177,7 @@ jobs:
           su - build -c "cd ${{ runner.workspace }}/meta-slint && \
             WORK_ROOT='${WORK_ROOT}' \
             ARTIFACT_DIR='${WORK_ROOT}/artifacts' \
+            ARTIFACT_BASENAME='${{ inputs.device }}-slint-demo' \
             SSTATE_DIR='${SSTATE_DIR}' \
             meta-slint/scripts/demo-images/${{ inputs.device }}.sh"
           echo "sstate objects after build:  $(find "$SSTATE_DIR" -name '*.tar.zst' 2>/dev/null | wc -l)"
@@ -164,14 +186,30 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           cd ${{ runner.workspace }}/build-${{ inputs.device }}/artifacts
-          # Bundle the collected image files into a single, stably-named zip --
-          # the same "<device>-demo-image.zip" you'd get by downloading the
-          # workflow artifact from the browser. -0 (store) avoids re-compressing
-          # the already-compressed .wic.zst. The stable name means --clobber
-          # replaces the asset in place on each build (no accumulation).
-          zip -j -0 "${{ inputs.device }}-demo-image.zip" ./*
-          gh release upload demo-images --repo "${{ github.repository }}" --clobber \
-            "${{ inputs.device }}-demo-image.zip"
+          if [ "${{ inputs.device }}" = "imx95-evk" ]; then
+            # The i.MX image is flashed with uuu/bmaptool rather than
+            # balenaEtcher, so bundle the .wic.zst + .bmap into a single,
+            # stably-named zip. -0 (store) avoids re-compressing the already
+            # compressed .wic.zst; the stable name lets --clobber replace the
+            # asset in place on each build (no accumulation).
+            zip -j -0 "${{ inputs.device }}-demo-image.zip" ./*
+            gh release upload demo-images --repo "${{ github.repository }}" --clobber \
+              "${{ inputs.device }}-demo-image.zip"
+          else
+            # The Raspberry Pi image is an uncompressed raw .img. Bundle it into
+            # <device>-slint-demo.zip: balenaEtcher opens the zip and flashes the
+            # single .img inside, and deflate shrinks the mostly-empty raw image
+            # so the download stays reasonable. Stable name -> --clobber replaces
+            # the previous build's asset in place.
+            shopt -s nullglob
+            files=(*)
+            if [ "${#files[@]}" -eq 0 ]; then
+              echo "::error::no artifacts found to publish"; exit 1
+            fi
+            zip -j "${{ inputs.device }}-slint-demo.zip" "${files[@]}"
+            gh release upload demo-images --repo "${{ github.repository }}" --clobber \
+              "${{ inputs.device }}-slint-demo.zip"
+          fi
       - name: "prune stale sstate objects"
         # Best-effort, and runs even if the build failed, to keep the shared
         # Volume from growing unbounded. Never fail the job over pruning.

--- a/dynamic-layers/meta-raspberrypi/recipes-graphics/images/rpi-image-slint-demos.bb
+++ b/dynamic-layers/meta-raspberrypi/recipes-graphics/images/rpi-image-slint-demos.bb
@@ -11,8 +11,21 @@ CORE_IMAGE_BASE_INSTALL += " \
     liberation-fonts \
 "
 
-# Emit a compressed .wic plus its block map, so the workflow can publish an
-# image that is flashable directly with bmaptool. WKS_FILE is the SD-card
-# layout shipped by meta-raspberrypi (FAT boot partition + ext4 rootfs).
-IMAGE_FSTYPES = "wic.zst wic.bmap"
+# Networking: this image runs systemd (see INIT_MANAGER in the build script), so
+# bring the network up with systemd-networkd. systemd-conf ships the default
+# wired.network (DHCP on en*/eth*), and avahi provides zeroconf/mDNS so the board
+# is reachable as <hostname>.local and can resolve other .local hosts.
+CORE_IMAGE_BASE_INSTALL += " \
+    systemd-conf \
+    avahi-daemon \
+    avahi-utils \
+    libnss-mdns \
+"
+
+# Emit a plain, uncompressed raw disk image (.wic). The workflow relabels it to
+# <device>-slint-demo.img and bundles it into <device>-slint-demo.zip;
+# balenaEtcher opens the zip and flashes the single raw .img to an SD card.
+# WKS_FILE is the SD-card layout shipped by meta-raspberrypi (FAT boot + ext4
+# rootfs).
+IMAGE_FSTYPES = "wic"
 WKS_FILE = "sdimage-raspberrypi.wks"

--- a/scripts/demo-images/common.sh
+++ b/scripts/demo-images/common.sh
@@ -95,20 +95,40 @@ EOF
 }
 
 # Copy the given files into $ARTIFACT_DIR so a later workflow step can publish
-# them as a GitHub Actions artifact. Missing globs are skipped with a warning;
-# erroring if nothing was collected. Requires:
-#   ARTIFACT_DIR - directory to copy the flashable artifacts into
+# them to the demo-images release. Missing globs are skipped with a warning;
+# erroring if nothing was collected. Optionally:
+#   ARTIFACT_DIR        - directory to copy the flashable artifacts into (required)
+#   ARTIFACT_BASENAME   - if set, each file is renamed to
+#                         "<ARTIFACT_BASENAME>.<label>.<xz|zst|bmap|...>".
+#                         OpenEmbedded stamps its deploy files with a build date,
+#                         so a stable name is what lets `gh release upload
+#                         --clobber` replace the previous asset in place instead
+#                         of piling up date-stamped files on the release.
+#   ARTIFACT_IMAGE_LABEL - the extension label to give the raw image (default
+#                         "wic"). A .wic is a plain raw disk image, so the Pi
+#                         builds relabel it to "img" -- the extension flashing
+#                         tools (balenaEtcher, Raspberry Pi Imager) expect.
 slint_demo_collect_artifacts() {
     local dest="${ARTIFACT_DIR:?ARTIFACT_DIR must be set}"
+    local label="${ARTIFACT_IMAGE_LABEL:-wic}"
     mkdir -p "$dest"
-    local f collected=0
+    local f base target collected=0
     for f in "$@"; do
         if [ ! -e "$f" ]; then
             echo "warning: no artifact matched '$f', skipping" >&2
             continue
         fi
-        echo "Collecting $(basename "$f") -> $dest"
-        cp -L "$f" "$dest/"
+        base="$(basename "$f")"
+        if [ -n "${ARTIFACT_BASENAME:-}" ]; then
+            # Keep the compression/type suffix (everything after the first
+            # ".wic") but swap the "wic" label, e.g. foo.rootfs.wic.xz ->
+            # <basename>.img.xz, foo.rootfs.wic.bmap -> <basename>.img.bmap.
+            target="$dest/${ARTIFACT_BASENAME}.${label}${base#*.wic}"
+        else
+            target="$dest/$base"
+        fi
+        echo "Collecting $base -> $target"
+        cp -L "$f" "$target"
         collected=$((collected + 1))
     done
     if [ "$collected" -eq 0 ]; then

--- a/scripts/demo-images/rpi-common.sh
+++ b/scripts/demo-images/rpi-common.sh
@@ -80,6 +80,10 @@ slint_demo_build_rpi() {
     # base image, carries the "synaptics-killswitch" license flag; accept it so the
     # firmware is buildable instead of skipped.
     echo 'LICENSE_FLAGS_ACCEPTED:append = " synaptics-killswitch"' >> conf/local.conf
+    # poky defaults to sysvinit, but the slint-demos autostart is a systemd unit
+    # and the image relies on systemd-networkd for DHCP -- switch the init
+    # manager to systemd so both actually run on boot.
+    echo 'INIT_MANAGER = "systemd"' >> conf/local.conf
     slint_demo_configure_local_conf conf/local.conf
 
     # Point sstate at a persistent cache (e.g. a mounted Hetzner Volume) when the
@@ -93,14 +97,17 @@ slint_demo_build_rpi() {
     bitbake "$image"
 
     # --- Collect the flashable image for the workflow to publish. ---
-    # Ship the compressed image plus its block map; bmaptool can flash the
-    # .wic.zst directly using the .bmap. Match by extension (OpenEmbedded adds a
-    # ".rootfs" infix), and restrict to regular files so OE's convenience
-    # symlinks don't duplicate the (large) image in the artifact.
+    # Ship the uncompressed raw image, relabelled from .wic to .img (a .wic is
+    # just a raw disk image). The workflow bundles it into <device>-slint-demo.zip
+    # so balenaEtcher can open the zip and flash the single .img to an SD card.
+    # Match by extension (OpenEmbedded adds a ".rootfs" infix), and restrict to
+    # regular files so OE's convenience symlink doesn't duplicate the (large)
+    # image in the artifact.
+    export ARTIFACT_IMAGE_LABEL=img
     local deploy="tmp/deploy/images/$machine"
     local -a slint_demo_images
     mapfile -t slint_demo_images < <(
-        find "$deploy" -maxdepth 1 -type f \( -name '*.wic.zst' -o -name '*.wic.bmap' \) | sort
+        find "$deploy" -maxdepth 1 -type f -name '*.wic' | sort
     )
     slint_demo_collect_artifacts "${slint_demo_images[@]}"
 }


### PR DESCRIPTION
The Pi images booted but never into the Slint demo, and the board got no IP address. The slint-demos autostart is a systemd unit, but the Pi build used poky's default sysvinit, so the unit was installed yet never started; sysvinit also left the wired link unconfigured, so there was no DHCP. Switch the Pi build to systemd (INIT_MANAGER = "systemd") so the demo service runs on boot, and pull in networking: systemd-conf for wired DHCP via systemd-networkd, plus avahi-daemon/avahi-utils/libnss-mdns for zeroconf so the board is reachable as <hostname>.local.

Also fold in the related demo-image fixes made while getting the Pi boards working end to end:

- Publish the Pi image as a zip containing a single, uncompressed raw disk image: build a plain .wic and upload <device>-slint-demo.zip containing <device>-slint-demo.img. The i.MX95 EVK keeps its own .zip (flashed with uuu/bmaptool), so the publish step zips per board accordingly.

- CI: before creating the next build's Hetzner server, poll the API until the shared sstate volume has detached from the previous build's server. A server's deletion -- and thus the volume detach -- completes asynchronously after the delete-runner job returns, so serialized back-to-back builds could otherwise fail to attach the volume.