### PR TITLE
Add STM32MP1 and STM32MP2 demo images

### DIFF
--- a/.github/workflows/build-one-device.yml
+++ b/.github/workflows/build-one-device.yml
@@ -1,0 +1,227 @@
+name: Build one demo image
+
+# Reusable workflow: build the Slint demo image for a SINGLE device on a
+# dedicated Hetzner instance and publish it to the rolling "demo-images" release.
+# The device id must match scripts/demo-images/<device>.sh. Secrets (via
+# `secrets: inherit`): GH_API_KEY (Hetzner runner action), HETZNER_API_KEY.
+
+on:
+  workflow_call:
+    inputs:
+      device:
+        description: "Device id (matches scripts/demo-images/<device>.sh)"
+        type: string
+        required: true
+      publish_to_release:
+        description: "Upload the image to the demo-images release; if false, keep it only as a workflow artifact"
+        type: boolean
+        default: true
+        required: false
+
+jobs:
+  prepare_env:
+    runs-on: ubuntu-latest
+    name: Create new Hetzner Cloud instance for build
+    outputs:
+      label: ${{ steps.create-runner.outputs.label }}
+      server_id: ${{ steps.create-runner.outputs.server_id }}
+    steps:
+      - name: "wait for the sstate volume to detach from the previous build"
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HETZNER_API_KEY }}
+        run: |
+          # A deleted Hetzner server detaches its volume asynchronously, after the
+          # previous build's delete-runner job returned. Wait until the shared
+          # sstate volume is free, else this build fails to attach it.
+          vol=106201634
+          for i in $(seq 1 60); do
+            server=$(curl -fsSL -H "Authorization: Bearer $HCLOUD_TOKEN" \
+              "https://api.hetzner.cloud/v1/volumes/$vol" | jq -r '.volume.server // "null"')
+            if [ "$server" = "null" ]; then
+              echo "sstate volume $vol is free after $((i - 1)) poll(s)"; exit 0
+            fi
+            echo "sstate volume $vol still attached to server $server; waiting ($i/60)..."
+            sleep 10
+          done
+          echo "::error::timed out waiting for sstate volume $vol to detach"; exit 1
+      - uses: Cyclenerd/hcloud-github-runner@v1
+        id: create-runner
+        with:
+          mode: create
+          github_token: ${{ secrets.GH_API_KEY }}
+          hcloud_token: ${{ secrets.HETZNER_API_KEY }}
+          # 32G RAM / 320G disk; must be created in the sstate volume's location
+          # (nbg1) to attach it. The action mounts it at /mnt/HC_Volume_<id>.
+          server_type: cx53
+          location: nbg1
+          volume: "106201634"
+
+  build:
+    runs-on: ${{ needs.prepare_env.outputs.label }}
+    needs: prepare_env
+    # For `gh release upload`.
+    permissions:
+      contents: write
+    # A from-scratch vendor BSP build runs past GitHub's default 6h limit.
+    timeout-minutes: 600
+    steps:
+      - uses: actions/checkout@v4
+        with:
+            path: 'meta-slint'
+      - name: dependency setup
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y chrpath diffstat lz4 locales build-essential wget cpio file gawk zstd python3 git curl xz-utils zip
+          sudo locale-gen en_US.UTF-8
+          sudo update-locale
+          # GitHub CLI (not preinstalled) to publish into the demo-images release.
+          sudo mkdir -p -m 755 /etc/apt/keyrings
+          wget -nv -O- https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+            | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null
+          sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+            | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+          sudo apt-get update
+          sudo apt-get install -y gh
+      - name: "user & machine setup"
+        run: |
+          # OE's pseudo/bitbake need unprivileged user namespaces, restricted by
+          # default on recent Ubuntu.
+          echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+          id -u build &>/dev/null || useradd -m build
+          echo "build ALL=(ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/build
+          chown -R build:build ${{ runner.workspace }}
+          # Mount the sstate cache from the attached Hetzner Volume ourselves (the
+          # runner action attaches it as a raw device but doesn't mount it). A
+          # Volume attaches to only one server at a time, so if another build holds
+          # it the mount fails -- fail hard rather than silently building cold on
+          # the ephemeral disk (which could also race the shared cache).
+          SSTATE_VOL=/dev/disk/by-id/scsi-0HC_Volume_106201634
+          SSTATE_MNT=/mnt/HC_Volume_106201634
+          if [ ! -b "$SSTATE_VOL" ]; then
+            echo "::error::sstate volume $SSTATE_VOL is not attached -- another build is likely holding it; failing."
+            lsblk; exit 1
+          fi
+          # Format once if the volume is still blank.
+          if ! sudo blkid "$SSTATE_VOL" >/dev/null 2>&1; then
+            echo "Volume has no filesystem; creating ext4 (one-time)."
+            sudo mkfs.ext4 -F -L sstate "$SSTATE_VOL"
+          fi
+          sudo mkdir -p "$SSTATE_MNT"
+          if ! mountpoint -q "$SSTATE_MNT"; then
+            sudo mount "$SSTATE_VOL" "$SSTATE_MNT" || {
+              echo "::error::failed to mount sstate volume $SSTATE_VOL -- another build may be holding it; failing."
+              lsblk; df -h; exit 1
+            }
+          fi
+          # Verify the mount really is the sstate volume before building on it.
+          if ! mountpoint -q "$SSTATE_MNT"; then
+            echo "::error::$SSTATE_MNT is not a mountpoint -- refusing to build without the sstate volume."
+            lsblk; df -h; exit 1
+          fi
+          mount_src=$(findmnt -no SOURCE --target "$SSTATE_MNT" || true)
+          if [ "$(readlink -f "$mount_src")" != "$(readlink -f "$SSTATE_VOL")" ]; then
+            echo "::error::$SSTATE_MNT is backed by '$mount_src', not the sstate volume $SSTATE_VOL; failing."
+            lsblk; df -h; exit 1
+          fi
+          echo "sstate volume mounted:"; df -h "$SSTATE_MNT"
+          sudo mkdir -p "$SSTATE_MNT/sstate-cache"
+          sudo chown build:build "$SSTATE_MNT/sstate-cache"
+      - name: "build ${{ inputs.device }} demo image"
+        run: |
+          SSTATE_DIR=/mnt/HC_Volume_106201634/sstate-cache
+          # Per-device build tree, so a reused runner never mixes two devices.
+          WORK_ROOT=${{ runner.workspace }}/build-${{ inputs.device }}
+          echo "sstate objects before build: $(find "$SSTATE_DIR" -name '*.tar.zst' 2>/dev/null | wc -l)"
+          su - build -c "cd ${{ runner.workspace }}/meta-slint && \
+            WORK_ROOT='${WORK_ROOT}' \
+            ARTIFACT_DIR='${WORK_ROOT}/artifacts' \
+            ARTIFACT_BASENAME='${{ inputs.device }}-slint-demo' \
+            SSTATE_DIR='${SSTATE_DIR}' \
+            meta-slint/scripts/demo-images/${{ inputs.device }}.sh"
+          echo "sstate objects after build:  $(find "$SSTATE_DIR" -name '*.tar.zst' 2>/dev/null | wc -l)"
+      - name: "package ${{ inputs.device }} image"
+        run: |
+          # Assemble the files to publish into publish/ so the upload steps are
+          # device-agnostic. Packaging differs per flashing method.
+          ART=${{ runner.workspace }}/build-${{ inputs.device }}/artifacts
+          PUB=${{ runner.workspace }}/build-${{ inputs.device }}/publish
+          mkdir -p "$PUB"
+          cd "$ART"
+          if [ "${{ inputs.device }}" = "imx95-evk" ]; then
+            # uuu/bmaptool bundle: .wic.zst + .bmap + bootloader + README. -0
+            # (store) since the .wic.zst is already compressed.
+            zip -j -0 "$PUB/${{ inputs.device }}-demo-image.zip" ./*
+          elif [ "${{ inputs.device }}" = "stm32mp1" ] || [ "${{ inputs.device }}" = "stm32mp2" ]; then
+            # STM32CubeProgrammer bundle (tarball, README inside) + standalone
+            # README, shipped as one zip. -0 since the tarball is already gzipped.
+            zip -j -0 "$PUB/${{ inputs.device }}-flash-bundle.zip" \
+              ./*-flash-bundle.tar.gz ./*-flash-bundle-README.txt
+          else
+            # Raspberry Pi: raw .img + README, deflated (the mostly-empty image
+            # shrinks a lot). A multi-file zip may need extracting before flashing.
+            shopt -s nullglob
+            imgs=(*.img)
+            if [ "${#imgs[@]}" -eq 0 ]; then
+              echo "::error::no .img artifact found to publish"; exit 1
+            fi
+            zip -j "$PUB/${{ inputs.device }}-slint-demo.zip" "${imgs[@]}" README.txt
+          fi
+          echo "Packaged for publishing:"; ls -l "$PUB"
+      - name: "upload ${{ inputs.device }} image to the demo-images release"
+        if: ${{ inputs.publish_to_release }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Stable asset names + --clobber replace the previous build's asset.
+          PUB=${{ runner.workspace }}/build-${{ inputs.device }}/publish
+          for f in "$PUB"/*; do
+            echo "Uploading $(basename "$f") to the demo-images release"
+            gh release upload demo-images --repo "${{ github.repository }}" --clobber "$f"
+          done
+      - name: "upload ${{ inputs.device }} image as a workflow artifact"
+        if: ${{ ! inputs.publish_to_release }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.device }}-demo-image
+          path: ${{ runner.workspace }}/build-${{ inputs.device }}/publish
+          retention-days: 14
+          if-no-files-found: error
+      - name: "prune stale sstate objects"
+        # Best-effort, runs even on failure, to bound the shared Volume's growth.
+        if: ${{ always() }}
+        continue-on-error: true
+        env:
+          SSTATE_MAX_AGE_DAYS: "30"
+        run: |
+          SSTATE_DIR=/mnt/HC_Volume_106201634/sstate-cache
+          if ! mountpoint -q /mnt/HC_Volume_106201634; then
+            echo "sstate volume not mounted; nothing to prune"; exit 0
+          fi
+          before=$(find "$SSTATE_DIR" -name '*.tar.zst' 2>/dev/null | wc -l)
+          # Prune least-recently-used by atime (bitbake reads objects on restore;
+          # relies on the volume's default relatime -- don't mount it noatime).
+          sudo find "$SSTATE_DIR" -type f -name '*.tar.zst'         -atime +"$SSTATE_MAX_AGE_DAYS" -delete
+          sudo find "$SSTATE_DIR" -type f -name '*.tar.zst.siginfo' -atime +"$SSTATE_MAX_AGE_DAYS" -delete
+          # Always drop Slint's own sstate so each image rebuilds Slint fresh.
+          sudo find "$SSTATE_DIR" -type f -name 'sstate:slint*' -delete
+          sudo find "$SSTATE_DIR" -mindepth 1 -type d -empty -delete 2>/dev/null || true
+          after=$(find "$SSTATE_DIR" -name '*.tar.zst' 2>/dev/null | wc -l)
+          echo "sstate objects: $before -> $after (dropped Slint + anything unused > ${SSTATE_MAX_AGE_DAYS} days)"
+
+  delete-runner:
+    name: Delete Runner
+    needs:
+      - prepare_env
+      - build
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+      - name: Delete runner
+        uses: Cyclenerd/hcloud-github-runner@v1
+        with:
+          mode: delete
+          github_token: ${{ secrets.GH_API_KEY }}
+          hcloud_token: ${{ secrets.HETZNER_API_KEY }}
+          name: ${{ needs.prepare_env.outputs.label }}
+          server_id: ${{ needs.prepare_env.outputs.server_id }}

--- a/.github/workflows/demo-images.yml
+++ b/.github/workflows/demo-images.yml
@@ -1,258 +1,82 @@
 name: Demo Images
 
-# Builds flashable Slint demo images for a selected set of devices and uploads
-# each into the rolling "demo-images" GitHub release, replacing the previous
-# asset in place. One script per device lives under scripts/demo-images/; add a
-# board by dropping in scripts/demo-images/<device>.sh and adding it to the
-# `device` choice input below. Each run builds the one device selected.
+# Build the checked boards as flashable Slint demo images (via the reusable
+# build-one-device.yml), one at a time -- they share a single Hetzner Volume for
+# the sstate cache, which attaches to only one server at a time.
 #
-# The "demo-images" prerelease is expected to already exist; CI only clobbers
-# its assets (which needs the built-in GITHUB_TOKEN with contents: write).
-#
-# A full NXP i.MX vendor BSP build is heavy (CPU, RAM and disk), so the build
-# runs on a dedicated Hetzner Cloud instance spun up for the job, mirroring
-# the CI workflow.
-#
-# Required repository secrets:
-#   GH_API_KEY       - GitHub token for the Hetzner runner action
-#   HETZNER_API_KEY  - Hetzner Cloud API token
+# Add a board: drop scripts/demo-images/<device>.sh, add a boolean input, add a
+# "select" line. Secrets: GH_API_KEY (Hetzner runner action), HETZNER_API_KEY.
 
 on:
   workflow_dispatch:
     inputs:
-      device:
-        description: "Device to build the Slint demo image for"
-        type: choice
-        required: true
-        default: imx95-evk
-        options:
-          - imx95-evk
-          - rpi5
-          - rpi4
+      imx95-evk:
+        description: "Build the i.MX95 EVK image"
+        type: boolean
+        default: false
+      rpi4:
+        description: "Build the Raspberry Pi 4 image"
+        type: boolean
+        default: false
+      rpi5:
+        description: "Build the Raspberry Pi 5 image"
+        type: boolean
+        default: false
+      stm32mp1:
+        description: "Build the STM32MP1 image (STM32MP15: DK1/DK2/EV1)"
+        type: boolean
+        default: false
+      stm32mp2:
+        description: "Build the STM32MP2 image (STM32MP25: e.g. STM32MP257F-DK)"
+        type: boolean
+        default: false
+      publish_to_release:
+        description: "Upload the built image(s) to the demo-images release (untick to keep them as workflow artifacts only)"
+        type: boolean
+        default: true
 
-# Only one demo-images build may run at a time: they share a single Hetzner
-# Volume for the sstate cache, and a Volume attaches to just one server. Queue
-# a new run behind the one in flight (cancel-in-progress: false) rather than
-# starting a doomed second build that can't get the volume.
+# Only one demo-images run at a time (shared Hetzner Volume); queue a new run
+# behind the one in flight rather than dropping it.
 concurrency:
   group: demo-images
   cancel-in-progress: false
 
 jobs:
-  prepare_env:
+  select:
     runs-on: ubuntu-latest
-    name: Create new Hetzner Cloud instance for build
+    name: Select boards
     outputs:
-      label: ${{ steps.create-runner.outputs.label }}
-      server_id: ${{ steps.create-runner.outputs.server_id }}
+      devices: ${{ steps.select.outputs.devices }}
     steps:
-      - name: "wait for the sstate volume to detach from the previous build"
-        env:
-          HCLOUD_TOKEN: ${{ secrets.HETZNER_API_KEY }}
+      - id: select
         run: |
-          # The concurrency group serializes runs, but a Hetzner server's
-          # deletion -- and therefore the detach of its attached volume --
-          # completes asynchronously, after the previous run's delete-runner job
-          # has already returned. If we create this run's server too soon, the
-          # create action fails to attach the shared sstate volume because the
-          # old server still holds it. Poll the volume until it is free.
-          vol=106201634
-          for i in $(seq 1 60); do
-            server=$(curl -fsSL -H "Authorization: Bearer $HCLOUD_TOKEN" \
-              "https://api.hetzner.cloud/v1/volumes/$vol" | jq -r '.volume.server // "null"')
-            if [ "$server" = "null" ]; then
-              echo "sstate volume $vol is free after $((i - 1)) poll(s)"; exit 0
-            fi
-            echo "sstate volume $vol still attached to server $server; waiting ($i/60)..."
-            sleep 10
-          done
-          echo "::error::timed out waiting for sstate volume $vol to detach"; exit 1
-      - uses: Cyclenerd/hcloud-github-runner@v1
-        id: create-runner
-        with:
-          mode: create
-          github_token: ${{ secrets.GH_API_KEY }}
-          hcloud_token: ${{ secrets.HETZNER_API_KEY }}
-          # Shared-vCPU box (32G RAM / 320G disk) -- the type the CI workflow
-          # already provisions reliably; rm_work keeps the BSP build within disk.
-          server_type: cx53
-          # Persistent sstate cache lives on a Hetzner Volume; the server must be
-          # created in the volume's location (nbg1) for the attach to succeed. The
-          # action mounts it at /mnt/HC_Volume_<id>.
-          location: nbg1
-          volume: "106201634"
+          # Checked boards -> JSON array for the build matrix. `[ test ] && cmd`
+          # is safe under set -e (a false test short-circuits without aborting).
+          devices=()
+          [ "${{ inputs['imx95-evk'] }}" = "true" ] && devices+=('"imx95-evk"')
+          [ "${{ inputs.rpi4 }}" = "true" ]              && devices+=('"rpi4"')
+          [ "${{ inputs.rpi5 }}" = "true" ]      && devices+=('"rpi5"')
+          [ "${{ inputs.stm32mp1 }}" = "true" ]  && devices+=('"stm32mp1"')
+          [ "${{ inputs.stm32mp2 }}" = "true" ]  && devices+=('"stm32mp2"')
+          if [ "${#devices[@]}" -eq 0 ]; then
+            echo "::error::Select at least one board to build."; exit 1
+          fi
+          IFS=,
+          echo "devices=[${devices[*]}]" >> "$GITHUB_OUTPUT"
+          echo "Building: [${devices[*]}]"
 
   build:
-    runs-on: ${{ needs.prepare_env.outputs.label }}
-    needs: prepare_env
-    # Needed for `gh release upload` to write assets to the demo-images release.
+    needs: select
+    # Write access for the release upload (the called workflow can't request more).
     permissions:
       contents: write
-    # A from-scratch vendor BSP build (no sstate mirror) runs past GitHub's
-    # default 6h job limit; self-hosted runners honour a higher timeout-minutes.
-    timeout-minutes: 600
-    steps:
-      - uses: actions/checkout@v4
-        with:
-            path: 'meta-slint'
-      - name: dependency setup
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y chrpath diffstat lz4 locales build-essential wget cpio file gawk zstd python3 git curl xz-utils zip
-          sudo locale-gen en_US.UTF-8
-          sudo update-locale
-          # GitHub CLI (not preinstalled on the ephemeral runner) to publish the
-          # image into the demo-images release.
-          sudo mkdir -p -m 755 /etc/apt/keyrings
-          wget -nv -O- https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-            | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null
-          sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-            | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
-          sudo apt-get update
-          sudo apt-get install -y gh
-      - name: "user & machine setup"
-        run: |
-          # OpenEmbedded's pseudo/bitbake rely on unprivileged user namespaces,
-          # which Ubuntu restricts by default on recent releases.
-          echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
-          # Idempotent, in case the runner is ever reused across jobs.
-          id -u build &>/dev/null || useradd -m build
-          echo "build ALL=(ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/build
-          chown -R build:build ${{ runner.workspace }}
-          # Persistent sstate cache on the attached Hetzner Volume. The runner
-          # action attaches the volume as a raw block device but does NOT mount
-          # it, so mount it ourselves -- otherwise the sstate dir would land on
-          # the ephemeral disk and every build would run cold.
-          #
-          # A Hetzner Volume can only be attached to ONE server at a time, so if
-          # another demo-images build is already running it holds this volume and
-          # the attach/mount here fails. That MUST fail the job hard: we never
-          # fall back to an unmounted (ephemeral) sstate dir, which would run
-          # cold and, worse, could let two builds race the shared cache. Every
-          # branch below therefore exits non-zero rather than continuing.
-          SSTATE_VOL=/dev/disk/by-id/scsi-0HC_Volume_106201634
-          SSTATE_MNT=/mnt/HC_Volume_106201634
-          if [ ! -b "$SSTATE_VOL" ]; then
-            echo "::error::sstate volume $SSTATE_VOL is not attached -- another build is likely holding it; failing."
-            lsblk; exit 1
-          fi
-          # Format once, only if the volume has no filesystem yet (safe: it
-          # starts empty). Only mkfs when blkid clearly reports no filesystem.
-          if ! sudo blkid "$SSTATE_VOL" >/dev/null 2>&1; then
-            echo "Volume has no filesystem; creating ext4 (one-time)."
-            sudo mkfs.ext4 -F -L sstate "$SSTATE_VOL"
-          fi
-          sudo mkdir -p "$SSTATE_MNT"
-          # Idempotent: skip the mount if already mounted (reused runner).
-          if ! mountpoint -q "$SSTATE_MNT"; then
-            sudo mount "$SSTATE_VOL" "$SSTATE_MNT" || {
-              echo "::error::failed to mount sstate volume $SSTATE_VOL -- another build may be holding it; failing."
-              lsblk; df -h; exit 1
-            }
-          fi
-          # Belt and braces: refuse to proceed unless the mount really is backed
-          # by the sstate volume, so a build can never run against the ephemeral
-          # disk with a stale/empty cache.
-          if ! mountpoint -q "$SSTATE_MNT"; then
-            echo "::error::$SSTATE_MNT is not a mountpoint -- refusing to build without the sstate volume."
-            lsblk; df -h; exit 1
-          fi
-          mount_src=$(findmnt -no SOURCE --target "$SSTATE_MNT" || true)
-          if [ "$(readlink -f "$mount_src")" != "$(readlink -f "$SSTATE_VOL")" ]; then
-            echo "::error::$SSTATE_MNT is backed by '$mount_src', not the sstate volume $SSTATE_VOL; failing."
-            lsblk; df -h; exit 1
-          fi
-          echo "sstate volume mounted:"; df -h "$SSTATE_MNT"
-          # Create the sstate dir and hand it to the build user.
-          sudo mkdir -p "$SSTATE_MNT/sstate-cache"
-          sudo chown build:build "$SSTATE_MNT/sstate-cache"
-      - name: "build ${{ inputs.device }} demo image"
-        run: |
-          SSTATE_DIR=/mnt/HC_Volume_106201634/sstate-cache
-          # Per-device build tree, so a reused runner never mixes one device's
-          # sources/ and build/ with another's.
-          WORK_ROOT=${{ runner.workspace }}/build-${{ inputs.device }}
-          echo "sstate objects before build: $(find "$SSTATE_DIR" -name '*.tar.zst' 2>/dev/null | wc -l)"
-          su - build -c "cd ${{ runner.workspace }}/meta-slint && \
-            WORK_ROOT='${WORK_ROOT}' \
-            ARTIFACT_DIR='${WORK_ROOT}/artifacts' \
-            ARTIFACT_BASENAME='${{ inputs.device }}-slint-demo' \
-            SSTATE_DIR='${SSTATE_DIR}' \
-            meta-slint/scripts/demo-images/${{ inputs.device }}.sh"
-          echo "sstate objects after build:  $(find "$SSTATE_DIR" -name '*.tar.zst' 2>/dev/null | wc -l)"
-      - name: "publish ${{ inputs.device }} image to the demo-images release"
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          cd ${{ runner.workspace }}/build-${{ inputs.device }}/artifacts
-          if [ "${{ inputs.device }}" = "imx95-evk" ]; then
-            # The i.MX image is flashed with uuu/bmaptool rather than
-            # balenaEtcher, so bundle the .wic.zst + .bmap into a single,
-            # stably-named zip. -0 (store) avoids re-compressing the already
-            # compressed .wic.zst; the stable name lets --clobber replace the
-            # asset in place on each build (no accumulation).
-            zip -j -0 "${{ inputs.device }}-demo-image.zip" ./*
-            gh release upload demo-images --repo "${{ github.repository }}" --clobber \
-              "${{ inputs.device }}-demo-image.zip"
-          else
-            # The Raspberry Pi image is an uncompressed raw .img. Bundle it into
-            # <device>-slint-demo.zip: balenaEtcher opens the zip and flashes the
-            # single .img inside, and deflate shrinks the mostly-empty raw image
-            # so the download stays reasonable. Stable name -> --clobber replaces
-            # the previous build's asset in place.
-            shopt -s nullglob
-            files=(*)
-            if [ "${#files[@]}" -eq 0 ]; then
-              echo "::error::no artifacts found to publish"; exit 1
-            fi
-            zip -j "${{ inputs.device }}-slint-demo.zip" "${files[@]}"
-            gh release upload demo-images --repo "${{ github.repository }}" --clobber \
-              "${{ inputs.device }}-slint-demo.zip"
-          fi
-      - name: "prune stale sstate objects"
-        # Best-effort, and runs even if the build failed, to keep the shared
-        # Volume from growing unbounded. Never fail the job over pruning.
-        if: ${{ always() }}
-        continue-on-error: true
-        env:
-          # Override to tune; objects not used by a build in this many days go.
-          SSTATE_MAX_AGE_DAYS: "30"
-        run: |
-          SSTATE_DIR=/mnt/HC_Volume_106201634/sstate-cache
-          if ! mountpoint -q /mnt/HC_Volume_106201634; then
-            echo "sstate volume not mounted; nothing to prune"; exit 0
-          fi
-          before=$(find "$SSTATE_DIR" -name '*.tar.zst' 2>/dev/null | wc -l)
-          # Prune by access time: bitbake reads an object (and its .siginfo)
-          # when it restores it, so -atime tracks "least recently used". This
-          # relies on the volume being mounted with atime updates (ext4's
-          # default relatime -- do NOT mount it noatime, or LRU info is lost).
-          sudo find "$SSTATE_DIR" -type f -name '*.tar.zst'         -atime +"$SSTATE_MAX_AGE_DAYS" -delete
-          sudo find "$SSTATE_DIR" -type f -name '*.tar.zst.siginfo' -atime +"$SSTATE_MAX_AGE_DAYS" -delete
-          # Never keep Slint's own sstate: the slint-cpp/slint-demos recipes
-          # track master, so their objects are per-build churn and -- worse -- a
-          # matching hash could restore a stale (non-latest) build. Dropping them
-          # every run forces each image to rebuild Slint from current master.
-          # The glob matches both the .tar.zst objects and their .siginfo files.
-          sudo find "$SSTATE_DIR" -type f -name 'sstate:slint*' -delete
-          sudo find "$SSTATE_DIR" -mindepth 1 -type d -empty -delete 2>/dev/null || true
-          after=$(find "$SSTATE_DIR" -name '*.tar.zst' 2>/dev/null | wc -l)
-          echo "sstate objects: $before -> $after (dropped Slint + anything unused > ${SSTATE_MAX_AGE_DAYS} days)"
-
-  delete-runner:
-    name: Delete Runner
-    needs:
-      - prepare_env
-      - build
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    steps:
-      - name: Delete runner
-        uses: Cyclenerd/hcloud-github-runner@v1
-        with:
-          mode: delete
-          github_token: ${{ secrets.GH_API_KEY }}
-          hcloud_token: ${{ secrets.HETZNER_API_KEY }}
-          name: ${{ needs.prepare_env.outputs.label }}
-          server_id: ${{ needs.prepare_env.outputs.server_id }}
+    strategy:
+      fail-fast: false      # one board failing shouldn't cancel the others
+      max-parallel: 1       # serialize: they share one Hetzner sstate Volume
+      matrix:
+        device: ${{ fromJson(needs.select.outputs.devices) }}
+    uses: ./.github/workflows/build-one-device.yml
+    with:
+      device: ${{ matrix.device }}
+      publish_to_release: ${{ inputs.publish_to_release }}
+    secrets: inherit

--- a/classes/slint_common.bbclass
+++ b/classes/slint_common.bbclass
@@ -1,5 +1,9 @@
 TARGET_CFLAGS:remove = "-fcanon-prefix-map"
 
+# The Skia renderer builds Skia from source with GN + ninja (skia-bindings), and
+# not every BSP provides ninja-native (OpenSTLinux doesn't), so depend on it.
+DEPENDS:append:class-target = " ninja-native"
+
 do_compile:prepend() {
     #export RUSTFLAGS="${RUSTFLAGS}"
     #export RUST_TARGET_PATH="${RUST_TARGET_PATH}"

--- a/dynamic-layers/meta-st-openstlinux/recipes-example/slint-demos/slint-demos/slint-demos.service
+++ b/dynamic-layers/meta-st-openstlinux/recipes-example/slint-demos/slint-demos/slint-demos.service
@@ -2,8 +2,10 @@
 Description=Startup script to launch Slint demo(s) on startup
 
 [Service]
-ExecStart=/usr/bin/energy-monitor
-Environment="SLINT_KMS_ROTATION=270"
+# The demo binary and screen rotation are substituted at do_install time from
+# the bbappend's SLINT_DEMO_BINARY / SLINT_KMS_ROTATION (per-MACHINE overrides).
+ExecStart=/usr/bin/@SLINT_DEMO_BINARY@
+Environment="SLINT_KMS_ROTATION=@SLINT_KMS_ROTATION@"
 
 [Install]
 WantedBy=multi-user.target

--- a/dynamic-layers/meta-st-openstlinux/recipes-example/slint-demos/slint-demos_%.bbappend
+++ b/dynamic-layers/meta-st-openstlinux/recipes-example/slint-demos/slint-demos_%.bbappend
@@ -3,6 +3,12 @@ inherit systemd
 SYSTEMD_AUTO_ENABLE = "enable"
 SYSTEMD_SERVICE:${PN} = "slint-demos.service"
 
+# Boot demo + screen rotation, per MACHINE. Defaults suit the STM32MP15 kits.
+SLINT_DEMO_BINARY ?= "energy-monitor"
+SLINT_DEMO_BINARY:stm32mp2 = "home-automation"
+SLINT_KMS_ROTATION ?= "270"
+SLINT_KMS_ROTATION:stm32mp2 = "0"
+
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI:append = " file://slint-demos.service file://touch_rotation.rules"
 FILES:${PN} += "${systemd_unitdir}/system/slint-demos.service"
@@ -11,6 +17,11 @@ FILES:${PN} += "${sysconfdir}/udev/rules.d/touch_rotation.rules"
 do_install:append() {
   install -d ${D}/${systemd_unitdir}/system
   install -m 0644 ${WORKDIR}/slint-demos.service ${D}/${systemd_unitdir}/system
+  # Substitute the per-MACHINE demo binary and rotation into the unit.
+  sed -i \
+    -e 's/@SLINT_DEMO_BINARY@/${SLINT_DEMO_BINARY}/g' \
+    -e 's/@SLINT_KMS_ROTATION@/${SLINT_KMS_ROTATION}/g' \
+    ${D}/${systemd_unitdir}/system/slint-demos.service
   install -d ${D}${sysconfdir}/udev/rules.d
   install -p -m 0644 ${WORKDIR}/touch_rotation.rules ${D}${sysconfdir}/udev/rules.d/
 }

--- a/dynamic-layers/meta-st-openstlinux/recipes-samples/images/st-image-slint-demos.bb
+++ b/dynamic-layers/meta-st-openstlinux/recipes-samples/images/st-image-slint-demos.bb
@@ -1,0 +1,19 @@
+SUMMARY = "A minimal OpenSTLinux image with the Slint demos, running via KMS/DRM"
+LICENSE = "GPL-3.0-only | Slint-Commercial"
+
+include recipes-st/images/st-image.inc
+
+inherit core-image features_check
+
+# LinuxKMS framebuffer backend, so no compositor.
+CONFLICT_DISTRO_FEATURES = "x11 wayland"
+
+IMAGE_LINGUAS = "en-us"
+
+IMAGE_FEATURES += "ssh-server-dropbear"
+
+# Just the demos (+ fonts), none of the dev framework st-example-image-slint
+# pulls in, to keep the image and its flashing bundle small.
+CORE_IMAGE_EXTRA_INSTALL += " \
+    packagegroup-framework-sample-slint \
+"

--- a/recipes-example/slint-demos/slint-demos_1.17.1.bb
+++ b/recipes-example/slint-demos/slint-demos_1.17.1.bb
@@ -1,7 +1,10 @@
 inherit cargo_bin
 inherit pkgconfig
 
-SRC_URI = "git://github.com/slint-ui/slint.git;protocol=https;branch=master;rev=master"
+# Pinned to a release (not master): the demos get reshuffled on master, e.g. the
+# cargo-workspace split that broke the build below. v1.17.1 tag.
+SLINT_REV = "cf62c975c311e7036d599ed8ed0b7e6a8386a934"
+SRC_URI = "git://github.com/slint-ui/slint.git;protocol=https;branch=release/1;rev=${SLINT_REV}"
 SRC_URI += "file://0001-WIP-v-1-14-0-Use-a-patched-gettext-to-avoid-cross-compiling-g.patch"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=1fa63388f53bdc8a49fc4eef67b55c87"
 
@@ -12,8 +15,6 @@ HOMEPAGE = "https://slint.dev/"
 LICENSE = "GPL-3.0-only | Slint-Commercial"
 
 inherit slint_common
-
-PV = "git-${SRCPV}"
 
 REQUIRED_DISTRO_FEATURES:append:class-target = "opengl"
 
@@ -43,8 +44,8 @@ do_compile:prepend() {
     export CURL_CA_BUNDLE
 }
 do_compile:append() {
-    # Reduce RAM requirements
-    export CARGO_PROFILE_RELEASE_LTO=false
+    export CARGO_PROFILE_RELEASE_LTO=false   # reduce RAM
+    # Build each demo binary; at v1.17.1 they're all members of the root workspace.
     for p in slide_puzzle printerdemo gallery opengl_texture opengl_underlay energy-monitor home-automation; do
         cargo build ${CARGO_BUILD_FLAGS} -p $p
     done

--- a/scripts/demo-images/common.sh
+++ b/scripts/demo-images/common.sh
@@ -1,12 +1,8 @@
 #!/bin/bash
-# Shared helpers for the per-device Slint demo image builds.
-#
-# This file is meant to be *sourced* by a per-device script (e.g.
-# imx95-evk.sh). It only defines functions; the device script owns the
-# `set -e` / control flow.
+# Shared helpers, sourced by a per-device script (e.g. imx95-evk.sh). Only
+# defines functions; the device script owns set -e / control flow.
 
-# Make sure Google's `repo` tool is available (NXP's BSP is consumed via a
-# repo manifest). Installs a private copy into ~/.local/bin if missing.
+# Install Google's `repo` (used to fetch vendor BSPs) into ~/.local/bin if missing.
 slint_demo_ensure_repo_tool() {
     if command -v repo >/dev/null 2>&1; then
         return 0
@@ -18,9 +14,8 @@ slint_demo_ensure_repo_tool() {
     export PATH="$HOME/.local/bin:$PATH"
 }
 
-# Add a layer only if it isn't already part of the build configuration. NXP's
-# i.MX BSP, for example, already ships and enables meta-clang, so adding our
-# own copy would trigger a duplicate BBFILE_COLLECTIONS parse error.
+# Add a layer only if not already present (some BSPs ship meta-clang etc., and a
+# duplicate would be a BBFILE_COLLECTIONS parse error).
 slint_demo_add_layer_if_missing() {
     local layer_path="$1"
     if bitbake-layers show-layers 2>/dev/null | grep -Fq "$layer_path"; then
@@ -30,21 +25,16 @@ slint_demo_add_layer_if_missing() {
     bitbake-layers add-layer "$layer_path"
 }
 
-# `repo` refuses to run without a git identity. Set a placeholder one only if
-# the environment doesn't already provide it.
+# `repo` refuses to run without a git identity; set a placeholder if unset.
 slint_demo_ensure_git_identity() {
     git config --global user.name  >/dev/null 2>&1 || git config --global user.name  "Slint CI"
     git config --global user.email >/dev/null 2>&1 || git config --global user.email "ci@slint.dev"
     git config --global color.ui false || true
 }
 
-# Append the configuration shared across every demo-image device to the given
-# conf/local.conf. Covers two things: the Slint build feature set and
-# aggressive disk-space conservation.
-#
-# Note: there is deliberately no public sstate mirror here. NXP's i.MX BSP
-# does not publish one, and the upstream poky/oe-core mirror doesn't match a
-# vendor BSP's metadata, so everything is built locally.
+# Append the config shared across every demo-image device to conf/local.conf:
+# the Slint feature set and disk-space conservation. No public sstate mirror --
+# vendor BSPs don't publish one, so everything builds locally.
 slint_demo_configure_local_conf() {
     local conf="$1"
     cat >> "$conf" <<'EOF'
@@ -54,22 +44,16 @@ slint_demo_configure_local_conf() {
 # clang is required for the Skia renderer.
 CLANGSDK = "1"
 
-# Render the demos directly on the framebuffer via KMS/DRM with the Skia
-# renderer, and ship the system-testing harness.
+# KMS/DRM framebuffer + Skia renderer, plus the system-testing harness.
 PACKAGECONFIG:append:pn-slint-cpp = " backend-linuxkms renderer-skia system-testing"
 
 # --- Disk-space conservation ---
 
-# Delete each recipe's WORKDIR as soon as it has been built. This is the single
-# biggest disk saver for a full vendor BSP image build; deploy artifacts under
-# DEPLOY_DIR_IMAGE are kept.
+# Delete each recipe's WORKDIR once built (biggest disk saver; deploy is kept).
 INHERIT += "rm_work"
-
-# Don't keep a per-recipe copy of fetched sources around in sstate tarballs.
 BB_GENERATE_MIRROR_TARBALLS = "0"
 
-# Stop scheduling new tasks (and abort outright) before the runner's disk
-# fills up, so a low-disk condition fails cleanly instead of corrupting state.
+# Abort cleanly before the runner's disk fills, rather than corrupting state.
 BB_DISKMON_DIRS = "\
     STOPTASKS,${TMPDIR},2G,100K \
     STOPTASKS,${DL_DIR},2G,100K \
@@ -78,36 +62,27 @@ BB_DISKMON_DIRS = "\
     ABORT,${DL_DIR},512M,1K \
     ABORT,${SSTATE_DIR},512M,1K"
 
-# --- Runner resource caps (Hetzner) ---
-# These two knobs carry very different memory risk, so keep them decoupled:
-#  - PARALLEL_MAKE is make-parallelism *within* one recipe. Compiling
-#    clang-native is the build's long pole (over an hour at -j4); -j8 speeds it
-#    up and 8 parallel compiles fit comfortably in the box's 32G RAM.
-#  - BB_NUMBER_THREADS is how many *recipes* build at once -- the real OOM
-#    lever, since it lets clang's heavy jobs collide with a rust/LTO link from
-#    another recipe. Keep it at the proven 4 to bound peak memory.
-# CARGO_BUILD_JOBS stays low because rustc + LTO linking the slint crate graph
-# can spike multiple GB per job.
+# Resource caps for the Hetzner box (32G RAM). BB_NUMBER_THREADS is the OOM lever
+# (parallel recipes), so keep it low; PARALLEL_MAKE speeds up the clang-native
+# long pole; CARGO_BUILD_JOBS stays low (rustc/LTO of the slint graph is heavy).
 BB_NUMBER_THREADS = "4"
 PARALLEL_MAKE = "-j 8"
 export CARGO_BUILD_JOBS = "2"
 EOF
+
+    # Reuse a persistent sstate cache (e.g. a mounted Hetzner Volume) when provided.
+    if [ -n "${SSTATE_DIR:-}" ]; then
+        echo "SSTATE_DIR = \"$SSTATE_DIR\"" >> "$conf"
+    fi
 }
 
-# Copy the given files into $ARTIFACT_DIR so a later workflow step can publish
-# them to the demo-images release. Missing globs are skipped with a warning;
-# erroring if nothing was collected. Optionally:
-#   ARTIFACT_DIR        - directory to copy the flashable artifacts into (required)
-#   ARTIFACT_BASENAME   - if set, each file is renamed to
-#                         "<ARTIFACT_BASENAME>.<label>.<xz|zst|bmap|...>".
-#                         OpenEmbedded stamps its deploy files with a build date,
-#                         so a stable name is what lets `gh release upload
-#                         --clobber` replace the previous asset in place instead
-#                         of piling up date-stamped files on the release.
-#   ARTIFACT_IMAGE_LABEL - the extension label to give the raw image (default
-#                         "wic"). A .wic is a plain raw disk image, so the Pi
-#                         builds relabel it to "img" -- the extension flashing
-#                         tools (balenaEtcher, Raspberry Pi Imager) expect.
+# Copy the given files into $ARTIFACT_DIR for a later workflow step to publish.
+# Missing globs warn; errors if nothing was collected. Optional:
+#   ARTIFACT_BASENAME    - rename each to "<basename>.<label><suffix-after-.wic>",
+#                          giving a stable name so `gh release upload --clobber`
+#                          replaces the previous (date-stamped) asset in place.
+#   ARTIFACT_IMAGE_LABEL - extension label for the raw image (default "wic"; the
+#                          Pi builds relabel .wic -> .img for their flashers).
 slint_demo_collect_artifacts() {
     local dest="${ARTIFACT_DIR:?ARTIFACT_DIR must be set}"
     local label="${ARTIFACT_IMAGE_LABEL:-wic}"
@@ -120,9 +95,8 @@ slint_demo_collect_artifacts() {
         fi
         base="$(basename "$f")"
         if [ -n "${ARTIFACT_BASENAME:-}" ]; then
-            # Keep the compression/type suffix (everything after the first
-            # ".wic") but swap the "wic" label, e.g. foo.rootfs.wic.xz ->
-            # <basename>.img.xz, foo.rootfs.wic.bmap -> <basename>.img.bmap.
+            # Swap the "wic" label, keep the suffix after it (foo.rootfs.wic.xz
+            # -> <basename>.img.xz).
             target="$dest/${ARTIFACT_BASENAME}.${label}${base#*.wic}"
         else
             target="$dest/$base"

--- a/scripts/demo-images/imx95-evk.sh
+++ b/scripts/demo-images/imx95-evk.sh
@@ -1,22 +1,10 @@
 #!/bin/bash
-# Build the Slint demo image for the NXP i.MX95 19x19 LPDDR5 EVK and collect the
-# flashable artifacts into $ARTIFACT_DIR for the workflow to publish.
+# Build the Slint demo image for the NXP i.MX95 19x19 LPDDR5 EVK. The BSP ships
+# as an NXP `repo` manifest; we pin a stable imx-linux-scarthgap release.
 #
-# The i.MX95 BSP only ships as an NXP `repo` manifest, so -- unlike the
-# qemuarm64 CI which bootstraps with bitbake-setup -- we fetch the BSP that
-# way. We pin a stable NXP release from the `imx-linux-scarthgap` branch
-# (Yocto 5.0 LTS), which matches meta-slint's main branch (scarthgap-compatible).
-#
-# Overridable via the environment:
-#   IMX_MANIFEST_BRANCH  default imx-linux-scarthgap
-#   IMX_MANIFEST_FILE    default imx-6.6.52-2.2.2.xml
-#   MACHINE              default imx95-19x19-lpddr5-evk
-#   DISTRO               default fsl-imx-wayland
-#   IMAGE                default imx-image-slint-demos
-#   WORK_ROOT            default $PWD (build tree is created here)
-#   ARTIFACT_DIR         default $WORK_ROOT/artifacts (flashable image copied here)
-#   SSTATE_DIR           unset (bitbake default); set to a persistent path to
-#                        reuse an sstate cache across builds
+# Env overrides: IMX_MANIFEST_BRANCH (imx-linux-scarthgap), IMX_MANIFEST_FILE
+# (imx-6.6.52-2.2.2.xml), MACHINE, DISTRO, IMAGE, WORK_ROOT, ARTIFACT_DIR,
+# SSTATE_DIR.
 set -euo pipefail
 
 IMX_MANIFEST_BRANCH="${IMX_MANIFEST_BRANCH:-imx-linux-scarthgap}"
@@ -26,7 +14,6 @@ DISTRO="${DISTRO:-fsl-imx-wayland}"
 IMAGE="${IMAGE:-imx-image-slint-demos}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# scripts/demo-images/<this> -> repo root is two levels up.
 META_SLINT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 # shellcheck source=scripts/demo-images/common.sh
 . "$SCRIPT_DIR/common.sh"
@@ -40,25 +27,19 @@ cd "$WORK_ROOT"
 slint_demo_ensure_git_identity
 slint_demo_ensure_repo_tool
 
-# --- Fetch the NXP i.MX BSP via repo. ---
+# Fetch the NXP i.MX BSP via repo.
 repo init -u https://github.com/nxp-imx/imx-manifest \
     -b "$IMX_MANIFEST_BRANCH" -m "$IMX_MANIFEST_FILE" --no-clone-bundle
 repo sync -j"$(nproc)" --no-clone-bundle
 
-# --- Set up the build directory. ---
-# imx-setup-release.sh is a sourced script that relies on a number of unset
-# variables and non-zero returns, so relax the shell's strict flags while it
-# runs. EULA=1 accepts the NXP end-user license non-interactively.
+# imx-setup-release.sh touches unset vars / returns non-zero, so relax strict
+# mode; EULA=1 accepts the NXP license non-interactively. Leaves us in build/.
 set +eu
 EULA=1 MACHINE="$MACHINE" DISTRO="$DISTRO" source ./imx-setup-release.sh -b build
 set -eu
 
-# imx-setup-release.sh leaves us inside the build directory.
-
-# --- Add meta-clang and meta-slint on top of the NXP layers. ---
-# The NXP i.MX BSP already ships and enables meta-clang, so only clone and add
-# our own copy if this BSP doesn't already provide one (adding a duplicate
-# trips a "duplicated BBFILE_COLLECTIONS 'clang-layer'" parse error).
+# Add meta-clang, meta-rust-bin and meta-slint. The BSP already ships meta-clang;
+# only add ours if not, to avoid a duplicate layer.
 META_CLANG_DIR="$WORK_ROOT/sources/meta-clang"
 if ! bitbake-layers show-layers 2>/dev/null | grep -Fq "/meta-clang"; then
     if [ ! -d "$META_CLANG_DIR" ]; then
@@ -69,9 +50,6 @@ else
     echo "meta-clang already provided by the BSP, skipping"
 fi
 
-# meta-slint (scarthgap) depends on meta-rust-bin's "rust-bin-layer" for the
-# prebuilt Rust toolchain. The NXP BSP uses oe-core's Rust and doesn't ship it,
-# so add it ourselves, before meta-slint, unless the BSP already provides it.
 META_RUST_BIN_DIR="$WORK_ROOT/sources/meta-rust-bin"
 if ! bitbake-layers show-layers 2>/dev/null | grep -Fq "/meta-rust-bin"; then
     if [ ! -d "$META_RUST_BIN_DIR" ]; then
@@ -84,27 +62,84 @@ fi
 
 slint_demo_add_layer_if_missing "$META_SLINT_DIR"
 
-# --- Slint / disk-conservation configuration. ---
 slint_demo_configure_local_conf conf/local.conf
 
-# Point sstate at a persistent cache (e.g. a mounted Hetzner Volume) when the
-# workflow provides one; DL_DIR is deliberately left at its default so downloads
-# stay ephemeral. A warm sstate restores most recipes without re-fetching.
-if [ -n "${SSTATE_DIR:-}" ]; then
-    echo "SSTATE_DIR = \"$SSTATE_DIR\"" >> conf/local.conf
-fi
-
-# --- Build. ---
 bitbake "$IMAGE"
 
-# --- Collect the flashable image for the workflow to publish as an artifact. ---
-# Ship the compressed image plus its block map; bmaptool can flash the .wic.zst
-# directly using the .bmap. Match by extension rather than guessing the full
-# file name: OpenEmbedded adds an infix (e.g. ".rootfs") and the exact name
-# varies by release. Restrict to regular files so OE's convenience symlinks
-# don't duplicate the (large) image in the artifact.
+# Ship the compressed image + its block map (bmaptool flashes the .wic.zst via
+# the .bmap). Match by extension (OE adds a ".rootfs" infix); regular files only,
+# so OE's symlinks don't duplicate the image.
 DEPLOY="tmp/deploy/images/$MACHINE"
 mapfile -t SLINT_DEMO_IMAGES < <(
     find "$DEPLOY" -maxdepth 1 -type f \( -name '*.wic.zst' -o -name '*.wic.bmap' \) | sort
 )
 slint_demo_collect_artifacts "${SLINT_DEMO_IMAGES[@]}"
+
+# Flashing bundle: the boot binary for UUU (eMMC over USB) alongside the image,
+# plus a README covering SD, UUU and picking the display device tree.
+BOOTLOADER="$(find "$DEPLOY" -maxdepth 1 -type f -name 'imx-boot-*flash_all' | sort | head -n1 || true)"
+if [ -z "$BOOTLOADER" ]; then
+    BOOTLOADER="$(find "$DEPLOY" -maxdepth 1 -type f -name 'imx-boot-*sd.bin*' | sort | head -n1 || true)"
+fi
+if [ -n "$BOOTLOADER" ]; then
+    cp -L "$BOOTLOADER" "$ARTIFACT_DIR/imx-boot-flash_all"
+    IMG_NAME="$(basename "$(find "$ARTIFACT_DIR" -maxdepth 1 -name '*.wic.zst' | sort | head -n1)")"
+    BMAP_NAME="$(basename "$(find "$ARTIFACT_DIR" -maxdepth 1 -name '*.wic.bmap' | sort | head -n1)")"
+    WIC_NAME="${IMG_NAME%.zst}"
+    cat > "$ARTIFACT_DIR/README.txt" <<EOF
+Flashing the i.MX95 EVK Slint demo image
+========================================
+
+This bundle contains:
+  $IMG_NAME   the demo image (compressed raw disk image)
+  $BMAP_NAME  block map, for flashing with bmaptool
+  imx-boot-flash_all             the i.MX boot binary, for flashing via UUU
+  README.txt                     this file
+
+The image boots into the Slint demo on the display.
+
+Option A -- SD card
+-------------------
+Write $IMG_NAME to an SD/microSD card:
+  * bmaptool:
+      bmaptool copy --bmap $BMAP_NAME $IMG_NAME /dev/sdX
+  * or decompress + dd:
+      zstd -d $IMG_NAME -o $WIC_NAME
+      sudo dd if=$WIC_NAME of=/dev/sdX bs=4M conv=fsync status=progress
+Set the board to boot from the SD card and power on. (Replace /dev/sdX with
+your card device.)
+
+Option B -- on-board eMMC via UUU (USB)
+---------------------------------------
+Program the eMMC over USB with NXP's Universal Update Utility (UUU), version
+1.5.220 or newer (https://github.com/nxp-imx/mfgtools/releases):
+  1. Put the i.MX95 19x19 EVK into serial-download mode -- switch SW4:
+         D1=ON  D2=OFF  D3=OFF  D4=OFF
+  2. Connect the board's USB-C download port to the host and power on.
+  3. Program the bootloader and image to eMMC (UUU decompresses the .zst):
+         uuu -b emmc_all imx-boot-flash_all $IMG_NAME
+  4. Power off, return SW4 to the normal boot-from-eMMC position, power on.
+
+Display output (device tree)
+----------------------------
+Which display output works is decided by the selected device tree (the boot
+partition ships several). If the screen stays blank, or you want a different
+display path, select the matching device tree at the U-Boot prompt:
+  1. Interrupt U-Boot during the boot countdown (press a key).
+  2. Select the device tree, save, and reboot:
+         setenv fdtfile <dtb-file>
+         saveenv
+         reset
+On the i.MX95 19x19 EVK, HDMI is provided through an add-on bridge, each with
+its own device tree -- list the exact names with 'ls mmc 1:1' in U-Boot (or
+'ls /boot' on the running board):
+  ...-it6263-lvds0.dtb   LVDS0 -> HDMI (IMX-LVDS-HDMI)
+  ...-adv7535-...dtb     MIPI-DSI -> HDMI (IMX-MIPI-HDMI)
+
+See the i.MX Linux User's Guide (UG10163) for details:
+https://www.nxp.com/docs/en/user-guide/UG10163.pdf
+EOF
+    echo "Added flashing files: $(basename "$BOOTLOADER") -> imx-boot-flash_all, README.txt"
+else
+    echo "warning: no imx-boot bootloader found under $DEPLOY; skipping flashing files" >&2
+fi

--- a/scripts/demo-images/rpi-common.sh
+++ b/scripts/demo-images/rpi-common.sh
@@ -1,23 +1,10 @@
 #!/bin/bash
-# Shared build steps for the Raspberry Pi Slint demo images.
+# Shared build for the Raspberry Pi Slint demo images. The rpi4.sh / rpi5.sh
+# wrappers set MACHINE, then call slint_demo_build_rpi; the rest is common.
+# meta-raspberrypi is a community layer, so we clone poky + the layers directly.
 #
-# The per-Pi scripts (rpi4.sh, rpi5.sh) differ only in the target MACHINE;
-# everything else -- the poky/meta-* checkout, the layer set, the distro
-# features and the artifact collection -- is identical, so it lives here.
-# Source common.sh and this file, set MACHINE, then call slint_demo_build_rpi.
-#
-# meta-raspberrypi is a plain community layer, so we bootstrap by cloning poky
-# and the extra layers directly (no vendor manifest or EULA involved).
-#
-# Reads from the environment (defaults in parentheses):
-#   YOCTO_RELEASE  (scarthgap)   branch used for poky + the OE layers
-#   MACHINE        (required)    set by the caller, e.g. raspberrypi5
-#   DISTRO         (poky)
-#   IMAGE          (rpi-image-slint-demos)
-#   WORK_ROOT      ($PWD)        build tree is created here
-#   ARTIFACT_DIR   ($WORK_ROOT/artifacts)  flashable image copied here
-#   SSTATE_DIR     (unset)       set to a persistent path to reuse an sstate cache
-#   META_SLINT_DIR (required)    path to this meta-slint checkout
+# Env: MACHINE, META_SLINT_DIR (required); YOCTO_RELEASE (scarthgap), DISTRO
+# (poky), IMAGE, WORK_ROOT, ARTIFACT_DIR, SSTATE_DIR (optional).
 
 slint_demo_build_rpi() {
     local yocto_release="${YOCTO_RELEASE:-scarthgap}"
@@ -51,16 +38,13 @@ slint_demo_build_rpi() {
         git clone https://github.com/rust-embedded/meta-rust-bin.git "$src/meta-rust-bin"
     fi
 
-    # --- Initialise the build directory. ---
-    # oe-init-build-env references unset variables (BBSERVER, ...) and returns
-    # non-zero in places, so relax the shell's strict flags while sourcing it.
+    # oe-init-build-env touches unset vars / returns non-zero, so relax strict mode.
     set +eu
     source "$src/poky/oe-init-build-env" "$work_root/build"
     set -eu
 
-    # --- Add the layers. Order matters for LAYERDEPENDS: meta-python before
-    # meta-networking, and meta-rust-bin before meta-slint. meta-raspberrypi
-    # depends on the meta-oe/python/multimedia/networking layers. ---
+    # Layer order matters for LAYERDEPENDS (meta-python before meta-networking,
+    # meta-rust-bin before meta-slint).
     bitbake-layers add-layer \
         "$src/meta-openembedded/meta-oe" \
         "$src/meta-openembedded/meta-python" \
@@ -71,38 +55,20 @@ slint_demo_build_rpi() {
         "$src/meta-rust-bin" \
         "$meta_slint_dir"
 
-    # --- Machine + Slint + disk-conservation configuration. ---
     echo "MACHINE = \"$machine\"" >> conf/local.conf
     echo "DISTRO ?= \"$distro\"" >> conf/local.conf
-    # The Slint demos need an OpenGL-capable distro (KMS/DRM + GLES via Mesa's V3D).
+    # KMS/DRM + GLES (Mesa V3D).
     echo 'DISTRO_FEATURES:append = " opengl"' >> conf/local.conf
-    # The Raspberry Pi WiFi firmware (linux-firmware-rpidistro), pulled in by the
-    # base image, carries the "synaptics-killswitch" license flag; accept it so the
-    # firmware is buildable instead of skipped.
+    # Accept the RPi WiFi firmware's license flag so it builds instead of skipping.
     echo 'LICENSE_FLAGS_ACCEPTED:append = " synaptics-killswitch"' >> conf/local.conf
-    # poky defaults to sysvinit, but the slint-demos autostart is a systemd unit
-    # and the image relies on systemd-networkd for DHCP -- switch the init
-    # manager to systemd so both actually run on boot.
+    # slint-demos autostart is a systemd unit and DHCP uses systemd-networkd.
     echo 'INIT_MANAGER = "systemd"' >> conf/local.conf
     slint_demo_configure_local_conf conf/local.conf
 
-    # Point sstate at a persistent cache (e.g. a mounted Hetzner Volume) when the
-    # workflow provides one; DL_DIR is deliberately left at its default so downloads
-    # stay ephemeral. A warm sstate restores most recipes without re-fetching.
-    if [ -n "${SSTATE_DIR:-}" ]; then
-        echo "SSTATE_DIR = \"$SSTATE_DIR\"" >> conf/local.conf
-    fi
-
-    # --- Build. ---
     bitbake "$image"
 
-    # --- Collect the flashable image for the workflow to publish. ---
-    # Ship the uncompressed raw image, relabelled from .wic to .img (a .wic is
-    # just a raw disk image). The workflow bundles it into <device>-slint-demo.zip
-    # so balenaEtcher can open the zip and flash the single .img to an SD card.
-    # Match by extension (OpenEmbedded adds a ".rootfs" infix), and restrict to
-    # regular files so OE's convenience symlink doesn't duplicate the (large)
-    # image in the artifact.
+    # Ship the raw image, relabelled .wic -> .img. Match by extension (OE adds a
+    # ".rootfs" infix); regular files only, so OE's symlink doesn't duplicate it.
     export ARTIFACT_IMAGE_LABEL=img
     local deploy="tmp/deploy/images/$machine"
     local -a slint_demo_images
@@ -110,4 +76,54 @@ slint_demo_build_rpi() {
         find "$deploy" -maxdepth 1 -type f -name '*.wic' | sort
     )
     slint_demo_collect_artifacts "${slint_demo_images[@]}"
+
+    # README, bundled into the zip alongside the .img.
+    local artifact_basename="${ARTIFACT_BASENAME:-${machine}-slint-demo}"
+    local board_desc
+    case "$machine" in
+        raspberrypi4*) board_desc="Raspberry Pi 4" ;;
+        raspberrypi5)  board_desc="Raspberry Pi 5" ;;
+        *)             board_desc="Raspberry Pi ($machine)" ;;
+    esac
+    local title="Slint demo image for the $board_desc"
+    local rule="${title//?/=}"
+    cat > "$ARTIFACT_DIR/README.txt" <<EOF
+$title
+$rule
+
+This image boots straight into the Slint demo, rendered on the HDMI display
+via KMS/DRM.
+
+Contents of ${artifact_basename}.zip:
+  ${artifact_basename}.img   a raw SD-card image (full disk: boot + root partitions)
+  README.txt                 this file
+
+Flashing an SD card
+-------------------
+The image is a plain raw disk image; use any image writer:
+
+  * Raspberry Pi Imager: "Use custom" -> select ${artifact_basename}.zip -> pick
+    the SD card.
+  * Command line:
+      unzip ${artifact_basename}.zip
+      sudo dd if=${artifact_basename}.img of=/dev/sdX bs=4M conv=fsync status=progress
+    (replace /dev/sdX with your SD card device)
+
+First boot
+----------
+Insert the card, connect an HDMI display, and power on. The Slint demo starts
+automatically on the screen.
+
+Networking
+----------
+  * Wired Ethernet comes up automatically via DHCP.
+  * Zeroconf/mDNS is enabled, so the board is reachable by name at
+    <hostname>.local -- the default hostname is the machine name, e.g.
+    ${machine}.local.
+  * An SSH server (dropbear) is running on port 22 (set a root password or key
+    to log in).
+
+Wi-Fi is not preconfigured.
+EOF
+    echo "Wrote README.txt"
 }

--- a/scripts/demo-images/stm32-common.sh
+++ b/scripts/demo-images/stm32-common.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# Shared build for the STMicroelectronics OpenSTLinux Slint demo images. The
+# stm32mp1.sh / stm32mp2.sh wrappers set MACHINE, the README example BOARD and
+# its BOOT_NOTE, then call slint_demo_build_stm32; the rest is common.
+#
+# Env: MACHINE, BOARD, META_SLINT_DIR (required); BOOT_NOTE, OSTL_MANIFEST_TAG,
+# OSTL_MANIFEST_FILE, DISTRO, IMAGE, WORK_ROOT, ARTIFACT_DIR, SSTATE_DIR (optional).
+
+slint_demo_build_stm32() {
+    local machine="${MACHINE:?set by the caller, e.g. stm32mp1}"
+    local board="${BOARD:?set by the caller (README example board)}"
+    local manifest_tag="${OSTL_MANIFEST_TAG:-openstlinux-6.6-yocto-scarthgap-mpu-v26.06.10}"
+    local manifest_file="${OSTL_MANIFEST_FILE:-default.xml}"
+    local distro="${DISTRO:-openstlinux-weston}"
+    local image="${IMAGE:-st-image-slint-demos}"
+    local meta_slint_dir="${META_SLINT_DIR:?set by the caller}"
+    # Apostrophe-free: an apostrophe inside a "${VAR:-default}" word still parses as a quote.
+    local default_boot_note='Put your board into USB serial-boot (flashing) mode and connect it to
+   the host. See the ST "Populate the target" guide for the exact boot-switch
+   settings for your board:
+     https://wiki.st.com/stm32mpu/wiki/Category:Let%27s_start'
+    local boot_note="${BOOT_NOTE:-$default_boot_note}"
+
+    local work_root="${WORK_ROOT:-$PWD}"
+    export ARTIFACT_DIR="${ARTIFACT_DIR:-$work_root/artifacts}"
+    mkdir -p "$work_root"
+    cd "$work_root"
+
+    slint_demo_ensure_git_identity
+    slint_demo_ensure_repo_tool
+
+    # Fetch the OpenSTLinux BSP via repo.
+    repo init -u https://github.com/STMicroelectronics/oe-manifest.git \
+        -b "refs/tags/$manifest_tag" -m "$manifest_file" --no-clone-bundle
+    repo sync -j"$(nproc)" --no-clone-bundle
+
+    # envsetup.sh prompts interactively on unsupported hosts and, with no stdin in
+    # CI, defaults to "no" and aborts. Pre-install the packages it wants and feed it
+    # a bounded number of "y"s. It must be sourced in this shell (brace group keeps
+    # the stdin redirect out of a subshell), and touches unset vars, so relax
+    # strict mode while it runs.
+    sudo apt-get update
+    sudo apt-get install -y \
+        bsdmainutils gcc-multilib git-lfs libgmp-dev libmpc-dev libssl-dev \
+        pylint python3-git python3-pip socat texinfo xterm || true
+    sudo apt-get install -y libsdl1.2-dev 2>/dev/null || true
+
+    set +eu
+    { DISTRO="$distro" MACHINE="$machine" source layers/meta-st/scripts/envsetup.sh; } < <(yes | head -n 20)
+    set -eu
+    if ! command -v bitbake-layers >/dev/null 2>&1; then
+        echo "::error::ST envsetup did not set up the build environment (bitbake not on PATH)"; exit 1
+    fi
+
+    # Add meta-clang, meta-rust-bin and meta-slint. The BSP may already ship
+    # meta-clang/meta-rust-bin; only add ours if not, to avoid a duplicate layer.
+    local meta_clang_dir="$work_root/layers/meta-clang"
+    if ! bitbake-layers show-layers 2>/dev/null | grep -Fq "/meta-clang"; then
+        [ -d "$meta_clang_dir" ] || git clone -b scarthgap https://github.com/kraj/meta-clang.git "$meta_clang_dir"
+        bitbake-layers add-layer "$meta_clang_dir"
+    fi
+    local meta_rust_bin_dir="$work_root/layers/meta-rust-bin"
+    if ! bitbake-layers show-layers 2>/dev/null | grep -Fq "/meta-rust-bin"; then
+        [ -d "$meta_rust_bin_dir" ] || git clone https://github.com/rust-embedded/meta-rust-bin.git "$meta_rust_bin_dir"
+        bitbake-layers add-layer "$meta_rust_bin_dir"
+    fi
+    slint_demo_add_layer_if_missing "$meta_slint_dir"
+
+    slint_demo_configure_local_conf conf/local.conf
+    cat >> conf/local.conf <<'EOF'
+
+# LinuxKMS framebuffer backend: no wayland/x11 (image sets CONFLICT_DISTRO_FEATURES).
+DISTRO_FEATURES:append = " opengl"
+DISTRO_FEATURES:remove = " wayland x11 vulkan opencl"
+EOF
+
+    bitbake "$image"
+
+    # STM32MP boards flash with STM32CubeProgrammer from a FlashLayout .tsv that
+    # references the partition binaries by relative path, so ship the whole deploy
+    # images dir as a tarball. Avoid `ls` to find it: its non-zero exit on a missing
+    # candidate would trip set -e before the -d check.
+    local deploy=""
+    local _d
+    for _d in "tmp-glibc/deploy/images/$machine" \
+              "tmp/deploy/images/$machine" \
+              "$work_root"/build-*/tmp-glibc/deploy/images/"$machine"; do
+        if [ -d "$_d" ]; then deploy="$_d"; break; fi
+    done
+    if [ -z "$deploy" ]; then
+        echo "::error::deploy images dir not found for $machine" >&2
+        find "$work_root" -maxdepth 6 -type d -name "$machine" -path '*deploy/images*' 2>/dev/null | head
+        exit 1
+    fi
+    echo "Deploy dir: $deploy"
+    echo "--- deploy contents ---"; ls -la "$deploy"
+    echo "--- FlashLayout .tsv files ---"; find "$deploy" -path '*flashlayout*' -name '*.tsv' | sort
+    echo "--- deploy size ---"; du -sh "$deploy" 2>/dev/null || true
+
+    # Drop the NAND (UBI/UBIFS) images and their FlashLayouts: the MP15 boards can
+    # boot from NAND, so OpenSTLinux emits ~0.8 GB of extra rootfs copies nobody
+    # flashing over SD/eMMC/NOR needs. No-op on machines without NAND (stm32mp2).
+    echo "--- pruning NAND (UBI/UBIFS) images from the bundle ---"
+    find "$deploy" \( -name '*.ubi' -o -name '*.ubifs' -o -name '*nand*' \) -print -delete 2>/dev/null || true
+    echo "--- deploy size after NAND prune ---"; du -sh "$deploy" 2>/dev/null || true
+
+    # SD-card (OP-TEE) FlashLayout for the README's worked example.
+    local tsv
+    tsv="$( { find "$deploy" -path "*flashlayout*/optee/FlashLayout_sdcard_${board}-optee.tsv"; \
+              find "$deploy" -path "*flashlayout*sdcard*${board}*.tsv"; } 2>/dev/null \
+            | sed "s#^${deploy}/##" | head -n1)"
+    echo "${board} SD-card FlashLayout: ${tsv:-<not found -- see the .tsv list above>}"
+
+    mkdir -p "$ARTIFACT_DIR"
+
+    # README written into the deploy dir so it lands at the root of the bundle.
+    local title="Flashing the ${machine^^} Slint demo image"
+    local rule="${title//?/=}"
+    cat > "$deploy/README.txt" <<EOF
+$title
+$rule
+
+This is the OpenSTLinux "images" directory for MACHINE=$machine -- the same
+layout ST ships in its Starter Package. The flashlayout_* directory holds one
+FlashLayout .tsv per board and boot scheme (SD card / eMMC / NOR), all sharing a
+single root filesystem, so this one bundle covers every board of the $machine
+family. The image boots straight into the Slint demo on the display (LinuxKMS
+backend).
+
+STM32MP boards are programmed over USB with STMicroelectronics'
+STM32CubeProgrammer, driven by a FlashLayout .tsv that lists the partitions and
+the binaries (paths relative to this directory) to write.
+
+1. Install STM32CubeProgrammer (provides STM32_Programmer_CLI):
+     https://www.st.com/en/development-tools/stm32cubeprog.html
+2. Extract this bundle:
+     tar xzf ${machine}-flash-bundle.tar.gz
+3. ${boot_note}
+4. Flash, pointing -w at the .tsv that matches your board and target storage.
+   Example -- ${board}, SD card, OP-TEE boot scheme:
+     STM32_Programmer_CLI -c port=usb1 -w ${tsv:-flashlayout_st-image-slint-demos/optee/FlashLayout_sdcard_${board}-optee.tsv}
+   For another board/storage, list the available layouts and pick one:
+     ls flashlayout_*/optee
+5. Set the boot switches back to boot from the flashed media and power-cycle.
+EOF
+
+    tar -czf "$ARTIFACT_DIR/${machine}-flash-bundle.tar.gz" -C "$deploy" .
+    # Also publish the README standalone so it's readable without the multi-GB download.
+    cp "$deploy/README.txt" "$ARTIFACT_DIR/${machine}-flash-bundle-README.txt"
+    echo "Wrote ${machine}-flash-bundle.tar.gz (README.txt inside) and ${machine}-flash-bundle-README.txt"
+}

--- a/scripts/demo-images/stm32mp1.sh
+++ b/scripts/demo-images/stm32mp1.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Build the Slint demo image for the STM32MP1 (STM32MP15: DK1/DK2/EV1). Just pins
+# MACHINE, the README example BOARD and its boot note; see stm32-common.sh.
+set -euo pipefail
+
+MACHINE="${MACHINE:-stm32mp1}"
+BOARD="${BOARD:-stm32mp157f-dk2}"
+# Apostrophe-free: an apostrophe inside a "${VAR:-default}" word still parses as a quote.
+DEFAULT_BOOT_NOTE='Put your board into USB serial-boot (flashing) mode and connect its USB-C
+   port to the host. On the STM32MP157F-DK2, set boot switch SW4 to
+   D1=ON  D2=OFF  D3=OFF  D4=OFF. See the ST "Populate the target" guide:
+     https://wiki.st.com/stm32mpu/wiki/Getting_started/STM32MP1_boards/STM32MP157x-DK2/Let%27s_start/Populate_the_target_and_boot_the_image'
+BOOT_NOTE="${BOOT_NOTE:-$DEFAULT_BOOT_NOTE}"
+export MACHINE BOARD BOOT_NOTE
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export META_SLINT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# shellcheck source=scripts/demo-images/common.sh
+. "$SCRIPT_DIR/common.sh"
+# shellcheck source=scripts/demo-images/stm32-common.sh
+. "$SCRIPT_DIR/stm32-common.sh"
+
+slint_demo_build_stm32

--- a/scripts/demo-images/stm32mp2.sh
+++ b/scripts/demo-images/stm32mp2.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Build the Slint demo image for the STM32MP2 (STM32MP25: e.g. STM32MP257F-DK).
+# Just pins MACHINE, the README example BOARD and its boot note; see
+# stm32-common.sh. The boot demo (home-automation here) is set in the bbappend.
+set -euo pipefail
+
+MACHINE="${MACHINE:-stm32mp2}"
+BOARD="${BOARD:-stm32mp257f-dk}"
+# Apostrophe-free: an apostrophe inside a "${VAR:-default}" word still parses as a quote.
+DEFAULT_BOOT_NOTE='Put your board into USB serial-boot (flashing) mode and connect its USB-C
+   port to the host. On the STM32MP257F-DK, set the boot-mode switches to the
+   serial-boot (DFU) position; see the ST "Populate the target" guide for the
+   exact switch settings for your board:
+     https://wiki.st.com/stm32mpu/wiki/Getting_started/STM32MP2_boards/STM32MP257x-DK/Let%27s_start/Populate_the_target_and_boot_the_image'
+BOOT_NOTE="${BOOT_NOTE:-$DEFAULT_BOOT_NOTE}"
+export MACHINE BOARD BOOT_NOTE
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export META_SLINT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# shellcheck source=scripts/demo-images/common.sh
+. "$SCRIPT_DIR/common.sh"
+# shellcheck source=scripts/demo-images/stm32-common.sh
+. "$SCRIPT_DIR/stm32-common.sh"
+
+slint_demo_build_stm32


### PR DESCRIPTION
Provide ready-to-flash Slint demo images for the STM32MP1 (STM32MP15) and STM32MP2 (STM32MP25) Discovery boards, alongside the existing Raspberry Pi and i.MX95 images, so users can grab a prebuilt image from the demo-images release and flash it without running a Yocto build themselves.

Pin Slint to the v1.17.1 release so the demo images build reproducibly, and publish each board as a single self-contained download.