### PR TITLE
Add TI AM62Px and AM62L Slint demo images

### DIFF
--- a/.github/workflows/demo-images.yml
+++ b/.github/workflows/demo-images.yml
@@ -30,6 +30,14 @@ on:
         description: "Build the STM32MP2 image (STM32MP25: e.g. STM32MP257F-DK)"
         type: boolean
         default: false
+      am62px:
+        description: "Build the TI AM62Px image (SK-AM62P-LP)"
+        type: boolean
+        default: false
+      am62l:
+        description: "Build the TI AM62L image (TMDS62LEVM, GPU-less / software rendering)"
+        type: boolean
+        default: false
       publish_to_release:
         description: "Upload the built image(s) to the demo-images release (untick to keep them as workflow artifacts only)"
         type: boolean
@@ -62,6 +70,8 @@ jobs:
           [ "${{ inputs.rpi5 }}" = "true" ]      && devices+=('"rpi5"')
           [ "${{ inputs.stm32mp1 }}" = "true" ]  && devices+=('"stm32mp1"')
           [ "${{ inputs.stm32mp2 }}" = "true" ]  && devices+=('"stm32mp2"')
+          [ "${{ inputs.am62px }}" = "true" ]    && devices+=('"am62px"')
+          [ "${{ inputs.am62l }}" = "true" ]     && devices+=('"am62l"')
           if [ "${#devices[@]}" -eq 0 ]; then
             echo "::error::Select at least one board to build."; exit 1
           fi

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -23,6 +23,8 @@ BBFILES_DYNAMIC += " \
     freescale-distro:${LAYERDIR}/dynamic-layers/meta-freescale-distro/*/*/*.bbappend \
     raspberrypi:${LAYERDIR}/dynamic-layers/meta-raspberrypi/*/*/*.bb \
     raspberrypi:${LAYERDIR}/dynamic-layers/meta-raspberrypi/*/*/*.bbappend \
+    meta-ti-bsp:${LAYERDIR}/dynamic-layers/meta-ti/*/*/*.bb \
+    meta-ti-bsp:${LAYERDIR}/dynamic-layers/meta-ti/*/*/*.bbappend \
     "
 
 LICENSE_PATH += "${LAYERDIR}/custom-licenses"

--- a/dynamic-layers/meta-ti/recipes-example/slint-demos/slint-demos/slint-demos.service
+++ b/dynamic-layers/meta-ti/recipes-example/slint-demos/slint-demos/slint-demos.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Startup script to launch Slint demo(s) on startup
+
+[Service]
+ExecStart=/usr/bin/home-automation
+
+[Install]
+WantedBy=multi-user.target

--- a/dynamic-layers/meta-ti/recipes-example/slint-demos/slint-demos_%.bbappend
+++ b/dynamic-layers/meta-ti/recipes-example/slint-demos/slint-demos_%.bbappend
@@ -1,0 +1,21 @@
+inherit systemd
+
+SYSTEMD_AUTO_ENABLE = "enable"
+SYSTEMD_SERVICE:${PN} = "slint-demos.service"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+SRC_URI:append = " file://slint-demos.service"
+FILES:${PN} += "${systemd_unitdir}/system/slint-demos.service"
+
+do_install:append() {
+  install -d ${D}/${systemd_unitdir}/system
+  install -m 0644 ${UNPACKDIR}/slint-demos.service ${D}/${systemd_unitdir}/system
+}
+
+# AM62L has no GPU: run the autostarted demo with Skia's software raster. The
+# image is built the same as the GPU boards (Slint's Skia renderer always links
+# GL), so software vs GPU is a runtime choice via SLINT_BACKEND.
+do_install:append:am62lxx-evm() {
+  sed -i '/^\[Service\]/a Environment=SLINT_BACKEND=linuxkms-skia-software' \
+    ${D}${systemd_unitdir}/system/slint-demos.service
+}

--- a/dynamic-layers/meta-ti/recipes-graphics/images/ti-image-slint-demos.bb
+++ b/dynamic-layers/meta-ti/recipes-graphics/images/ti-image-slint-demos.bb
@@ -1,0 +1,63 @@
+SUMMARY = "A minimal image with the Slint demos, running on TI Sitara via KMS/DRM"
+
+LICENSE = "MIT"
+
+inherit core-image
+
+IMAGE_FEATURES += "ssh-server-dropbear"
+
+CORE_IMAGE_BASE_INSTALL += " \
+    slint-demos \
+    slint-viewer \
+    liberation-fonts \
+"
+
+# systemd-networkd + avahi so the board comes up on DHCP and is reachable as
+# <hostname>.local (the image runs systemd; see INIT_MANAGER in the build script).
+CORE_IMAGE_BASE_INSTALL += " \
+    systemd-conf \
+    avahi-daemon \
+    avahi-utils \
+    libnss-mdns \
+"
+
+# The KMS/DRM display path. TI's kernel builds the display-subsystem driver
+# (tidss) and the on-board HDMI bridge (sii902x on the SK boards) as loadable
+# modules, but the machine config doesn't mark them essential -- so a bare
+# core-image ships without them and /dev/dri ends up with only a render node and
+# no HDMI connector, leaving the screen dark. Pull in the full built module set
+# so tidss and its bridge/connector chain land in the image. Both boards need
+# this: the demo scans out via tidss whether it renders on the GPU (AM62Px) or
+# in software (AM62L).
+CORE_IMAGE_BASE_INSTALL += " kernel-modules"
+
+# AM62Px has the PowerVR AXE-1-16M GPU. A bare core-image pulls in no graphics
+# stack, and Slint's Skia renderer loads EGL/GLES via dlopen (there's no ELF
+# NEEDED entry), so nothing drags them in implicitly -- the pvrsrvkm kernel
+# module and libEGL/libGLESv2 end up absent at runtime. Install just the minimal
+# GPU runtime the demo needs: Mesa's EGL/GLES/GBM via the PowerVR Gallium driver
+# (mesa-megadriver RRECOMMENDS the pvrsrvkm ti-img-rogue-driver) and the Rogue
+# DDK user libraries, which RDEPEND that kernel module and its firmware. We skip
+# the arago-graphics packagegroup on purpose: it drags in glmark2/kmscube, and
+# glmark2 wants wayland-protocols -- but this is a KMS/DRM image with no
+# compositor, so wayland stays out of the target. (AM62L has no GPU and renders
+# in software, so it gets none of this.)
+IMAGE_INSTALL:append:am62pxx-evm = " \
+    ti-img-rogue-umlibs \
+    mesa-megadriver \
+    libegl libgles2 libgbm \
+"
+
+# Raw SD-card image; the workflow relabels it to <device>-slint-demo.img and zips
+# it. The machine (am62pxx-evm / am62lxx-evm) provides the TI SD-card WKS
+# (tiboot3/tispl/u-boot boot partition + ext4 rootfs).
+IMAGE_FSTYPES = "wic"
+
+# AM62L has no GPU. The autostarted demo picks the Skia software backend via its
+# systemd unit; also default interactive/remote-viewer (slint-viewer) runs to it
+# by putting it in the login environment. (systemd services don't read
+# /etc/environment, hence the separate unit setting.)
+set_slint_software_backend() {
+    echo 'SLINT_BACKEND=linuxkms-skia-software' >> ${IMAGE_ROOTFS}${sysconfdir}/environment
+}
+ROOTFS_POSTPROCESS_COMMAND:append:am62lxx-evm = " set_slint_software_backend;"

--- a/recipes-slint/slint-viewer/slint-viewer_1.17.1.bb
+++ b/recipes-slint/slint-viewer/slint-viewer_1.17.1.bb
@@ -57,13 +57,9 @@ do_compile:prepend() {
     export CARGO_HTTP_TIMEOUT=120
     export CARGO_NET_RETRY=5
 
-    # Skia + LTO is very RAM-hungry; keep LTO off (as slint-demos does).
+    # Skia + LTO is very RAM-hungry; keep LTO off (as slint-demos does). The job
+    # count is bounded globally via CARGO_BUILD_JOBS (see common.sh).
     export CARGO_PROFILE_RELEASE_LTO=false
-
-    # Cargo otherwise fans out rustc to all host cores, and Skia's build script
-    # reads NUM_JOBS (which cargo derives from this) for its internal ninja.
-    # Cap both to keep peak memory bounded and avoid OOM.
-    export CARGO_BUILD_JOBS="6"
 }
 
 INSANE_SKIP:${PN} += "buildpaths"

--- a/scripts/demo-images/am62l.sh
+++ b/scripts/demo-images/am62l.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Build the Slint demo image for the TI Sitara AM62L EVM (TMDS62LEVM). Same SDK
+# and flow as the AM62Px build (see ti-common.sh), but the AM62L has no GPU:
+# Slint's Skia renderer still builds with GL (it always links it), yet renders
+# in software at runtime, and the proprietary Imagination GPU driver is left out.
+set -euo pipefail
+
+MACHINE="${MACHINE:-am62lxx-evm}"
+BOARD_DESC="${BOARD_DESC:-TI AM62L EVM (TMDS62LEVM)}"
+# No GPU: don't pull the proprietary Imagination DDK. The recipes select Skia's
+# software raster at runtime (SLINT_BACKEND=linuxkms-skia-software) for this
+# machine; nothing else differs from the AM62Px build.
+TI_GPU="${TI_GPU:-0}"
+export MACHINE BOARD_DESC TI_GPU
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export META_SLINT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# shellcheck source=scripts/demo-images/common.sh
+. "$SCRIPT_DIR/common.sh"
+# shellcheck source=scripts/demo-images/ti-common.sh
+. "$SCRIPT_DIR/ti-common.sh"
+
+slint_demo_build_ti

--- a/scripts/demo-images/am62px.sh
+++ b/scripts/demo-images/am62px.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Build the Slint demo image for the TI Sitara AM62Px (SK-AM62P-LP). Just pins
+# MACHINE and the board description; see ti-common.sh.
+set -euo pipefail
+
+MACHINE="${MACHINE:-am62pxx-evm}"
+BOARD_DESC="${BOARD_DESC:-TI SK-AM62P-LP (AM62Px)}"
+export MACHINE BOARD_DESC
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export META_SLINT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# shellcheck source=scripts/demo-images/common.sh
+. "$SCRIPT_DIR/common.sh"
+# shellcheck source=scripts/demo-images/ti-common.sh
+. "$SCRIPT_DIR/ti-common.sh"
+
+slint_demo_build_ti

--- a/scripts/demo-images/common.sh
+++ b/scripts/demo-images/common.sh
@@ -46,6 +46,9 @@ CLANGSDK = "1"
 # KMS/DRM framebuffer + Skia renderer, plus the system-testing harness.
 PACKAGECONFIG:append:pn-slint-cpp = " backend-linuxkms renderer-skia system-testing"
 
+# The demo images don't ship an SBOM; skip SPDX generation.
+INHERIT:remove = "create-spdx"
+
 # --- Disk-space conservation ---
 
 # Delete each recipe's WORKDIR once built (biggest disk saver; deploy is kept).
@@ -63,10 +66,13 @@ BB_DISKMON_DIRS = "\
 
 # Resource caps for the Hetzner box (32G RAM). BB_NUMBER_THREADS is the OOM lever
 # (parallel recipes), so keep it low; PARALLEL_MAKE speeds up the clang-native
-# long pole; CARGO_BUILD_JOBS stays low (rustc/LTO of the slint graph is heavy).
+# long pole. CARGO_BUILD_JOBS bounds cargo/rustc and Skia's internal ninja (it
+# reads NUM_JOBS, which cargo derives from this); the Slint+Skia graph is the
+# long pole, so give it a few jobs. LTO is off in those recipes, which keeps the
+# peak RAM of the parallel Skia C++ compiles in check.
 BB_NUMBER_THREADS = "4"
 PARALLEL_MAKE = "-j 8"
-export CARGO_BUILD_JOBS = "2"
+export CARGO_BUILD_JOBS = "6"
 EOF
 
     # Reuse a persistent sstate cache (the shared Hetzner Volume) when provided.

--- a/scripts/demo-images/ti-common.sh
+++ b/scripts/demo-images/ti-common.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# Shared build for the TI Sitara Slint demo images (currently AM62Px). The
+# am62px.sh wrapper sets MACHINE and the board description, then calls
+# slint_demo_build_ti; the rest is common.
+#
+# The TI Processor SDK ships as an Arago oe-layersetup config (like ST's/NXP's
+# repo manifests): oe-layertool-setup.sh clones poky + meta-arm + meta-ti + the
+# OE layers at TI's pinned, tested revisions and writes bblayers.conf. We add
+# meta-clang + meta-slint on top. The default config is SDK 12, which is on the
+# wrynose OE series (matches meta-slint on the dev branch).
+#
+# Env: MACHINE, BOARD_DESC, META_SLINT_DIR (required); TI_OECONFIG,
+# OE_LAYERSETUP_URL, META_CLANG_BRANCH, IMAGE, WORK_ROOT, ARTIFACT_DIR,
+# SSTATE_DIR (optional).
+
+slint_demo_build_ti() {
+    local machine="${MACHINE:?set by the caller, e.g. am62pxx-evm}"
+    local board_desc="${BOARD_DESC:-TI $machine}"
+    local image="${IMAGE:-ti-image-slint-demos}"
+    local meta_slint_dir="${META_SLINT_DIR:?set by the caller}"
+    local oe_layersetup_url="${OE_LAYERSETUP_URL:-https://git.ti.com/git/arago-project/oe-layersetup.git}"
+    local ti_oeconfig="${TI_OECONFIG:-configs/processor-sdk/processor-sdk-master-12.00.00.07.04-config.txt}"
+    # meta-clang tracks the same OE as the SDK; SDK 12 is on OE master.
+    local meta_clang_branch="${META_CLANG_BRANCH:-master}"
+
+    local work_root="${WORK_ROOT:-$PWD}"
+    export ARTIFACT_DIR="${ARTIFACT_DIR:-$work_root/artifacts}"
+    mkdir -p "$work_root"
+    cd "$work_root"
+
+    slint_demo_ensure_git_identity
+
+    # Host packages the TI Processor SDK build expects (Yocto build docs).
+    sudo apt-get update
+    sudo apt-get install -y \
+        build-essential chrpath cpio diffstat file gawk git-lfs lz4 pigz \
+        python3 python3-git python3-jinja2 python3-pexpect socat texinfo \
+        u-boot-tools unzip wget xz-utils zstd || true
+
+    # Fetch the BSP via TI's oe-layersetup (pinned Processor SDK revisions). It
+    # clones the layers under <setup>/sources and writes <setup>/build.
+    local setup="$work_root/oe-layersetup"
+    [ -d "$setup/.git" ] || git clone "$oe_layersetup_url" "$setup"
+    ( cd "$setup" && ./oe-layertool-setup.sh -f "$ti_oeconfig" )
+
+    # conf/setenv sources oe-init-build-env; run it in this shell (relaxing strict
+    # flags, as it touches unset vars) so bitbake lands on PATH.
+    local build="$setup/build"
+    set +eu
+    cd "$build"
+    . conf/setenv
+    set -eu
+    if ! command -v bitbake-layers >/dev/null 2>&1; then
+        echo "::error::TI oe-layersetup did not set up the build environment (bitbake not on PATH)"; exit 1
+    fi
+
+    # Add meta-clang and meta-slint on top of the TI layers. meta-slint on this
+    # (wrynose) branch builds Rust via oe-core's cargo, so no meta-rust-bin.
+    local layers="$setup/sources"
+    local meta_clang_dir="$layers/meta-clang"
+    if ! bitbake-layers show-layers 2>/dev/null | grep -Fq "/meta-clang"; then
+        [ -d "$meta_clang_dir" ] || git clone -b "$meta_clang_branch" https://github.com/kraj/meta-clang.git "$meta_clang_dir"
+        bitbake-layers add-layer "$meta_clang_dir"
+    fi
+    slint_demo_add_layer_if_missing "$meta_slint_dir"
+
+    echo "MACHINE = \"$machine\"" >> conf/local.conf
+    cat >> conf/local.conf <<'EOF'
+
+# Framebuffer/KMS demo, no compositor. opengl is required at build time even for
+# GPU-less boards: Slint's Skia renderer always links GL, so GLES/EGL must be
+# present to build (it just isn't used at runtime when rendering in software).
+DISTRO_FEATURES:append = " opengl"
+DISTRO_FEATURES:remove = " wayland x11 vulkan opencl"
+EOF
+    # GPU boards (AM62Px) render with the GPU via TI's proprietary Imagination
+    # DDK; accept its license so the GLES userspace is built in. GPU-less boards
+    # (AM62L) leave it out and let Skia raster in software (TI_GPU=0, set by the
+    # wrapper; the recipes select the software backend for that machine).
+    if [ "${TI_GPU:-1}" = "1" ]; then
+        echo 'LICENSE_FLAGS_ACCEPTED:append = " ti-img-rogue"' >> conf/local.conf
+    fi
+    echo 'INIT_MANAGER = "systemd"' >> conf/local.conf
+    slint_demo_configure_local_conf conf/local.conf
+
+    bitbake "$image"
+
+    # Ship the raw .wic, relabelled .wic -> .img (flash to SD, like the Pi). Match
+    # by extension (OE adds a ".rootfs" infix); regular files only, so OE's symlink
+    # doesn't duplicate it.
+    export ARTIFACT_IMAGE_LABEL=img
+    # Resolve the image deploy dir from bitbake -- the TI/Arago config uses a
+    # non-default TMPDIR (arago-tmp/, not tmp/), so don't hardcode the path. Fall
+    # back to a tree search, then fail loudly rather than run `find ''`.
+    local deploy
+    deploy="$(bitbake -e "$image" 2>/dev/null | sed -n 's/^DEPLOY_DIR_IMAGE="\(.*\)"$/\1/p' | tail -n1)"
+    if [ -z "$deploy" ] || [ ! -d "$deploy" ]; then
+        deploy="$(find "$build" -type d -path "*/deploy/images/$machine" 2>/dev/null | head -n1)"
+    fi
+    if [ -z "$deploy" ] || [ ! -d "$deploy" ]; then
+        echo "::error::could not locate the image deploy dir for $machine under $build"
+        find "$build" -type d -path '*deploy/images*' 2>/dev/null | head -n 20 || true
+        return 1
+    fi
+    echo "Image deploy dir: $deploy"
+    local -a slint_demo_images
+    mapfile -t slint_demo_images < <(
+        find "$deploy" -maxdepth 1 -type f -name '*.wic' | sort
+    )
+    slint_demo_collect_artifacts "${slint_demo_images[@]}"
+
+    # README, bundled into the zip alongside the .img.
+    local artifact_basename="${ARTIFACT_BASENAME:-${machine}-slint-demo}"
+    local title="Slint demo image for the $board_desc"
+    local rule="${title//?/=}"
+    cat > "$ARTIFACT_DIR/README.txt" <<EOF
+$title
+$rule
+
+This image boots straight into the Slint demo, rendered on the HDMI display
+via KMS/DRM.
+
+Contents of ${artifact_basename}.zip:
+  ${artifact_basename}.img   a raw SD-card image (full disk: boot + root partitions)
+  README.txt                 this file
+
+Flashing an SD card
+-------------------
+The image is a plain raw disk image; use any image writer:
+
+  * balenaEtcher / Raspberry Pi Imager: select ${artifact_basename}.zip (or the
+    extracted .img) and pick the SD card.
+  * Command line:
+      unzip ${artifact_basename}.zip
+      sudo dd if=${artifact_basename}.img of=/dev/sdX bs=4M conv=fsync status=progress
+    (replace /dev/sdX with your SD card device)
+
+First boot
+----------
+Set the board's boot switches to SD-card boot, insert the card, connect an HDMI
+display, and power on. The Slint demo starts automatically on the screen.
+
+Networking
+----------
+  * Wired Ethernet comes up automatically via DHCP.
+  * Zeroconf/mDNS is enabled, so the board is reachable at <hostname>.local
+    (default hostname is the machine name, e.g. ${machine}.local).
+  * An SSH server (dropbear) is running on port 22 (set a root password or key
+    to log in).
+EOF
+    echo "Wrote README.txt"
+}


### PR DESCRIPTION
Build flashable Slint demo images for the TI Sitara AM62Px (SK-AM62P-LP) and AM62L (TMDS62LEVM) via TI's Arago Processor SDK (SDK 12 / OE wrynose), published to the rolling demo-images release like the Raspberry Pi, i.MX and STM32 boards. The demos render on the framebuffer via KMS/DRM -- with the Imagination GPU on the AM62Px, and software rendering on the GPU-less AM62L.

Built on a dedicated Hetzner cx53 runner via the reusable build-one-device workflow, with the sstate cache kept directly on a shared Hetzner Volume (plus a hash-equivalence DB on the Volume) so warm rebuilds restore rather than build the world from scratch.