### PR TITLE
Additional fixes for am62l

### DIFF
--- a/dynamic-layers/meta-ti/recipes-example/slint-demos/slint-demos/99-drm-device-unit.rules
+++ b/dynamic-layers/meta-ti/recipes-example/slint-demos/slint-demos/99-drm-device-unit.rules
@@ -1,0 +1,5 @@
+# Tag DRM card devices so systemd creates a dev-dri-cardN.device unit for each.
+# Without this tag systemd never materialises dev-dri-card0.device, so the
+# slint-demos service (which orders itself After that unit) would have nothing to
+# wait on and could start before tidss/sii902x probe the display.
+ACTION=="add", SUBSYSTEM=="drm", KERNEL=="card*", TAG+="systemd"

--- a/dynamic-layers/meta-ti/recipes-example/slint-demos/slint-demos/slint-demos.service
+++ b/dynamic-layers/meta-ti/recipes-example/slint-demos/slint-demos/slint-demos.service
@@ -1,8 +1,21 @@
 [Unit]
 Description=Startup script to launch Slint demo(s) on startup
+# tidss (the display controller) and its HDMI bridge (sii902x) are loadable
+# kernel modules that only probe a few seconds into boot, so /dev/dri/card0
+# doesn't exist yet when systemd would otherwise start us -- the demo then fails
+# to open the DRM device. Order after the card's device unit, which systemd
+# materialises once the DRM device is tagged for it (see 99-drm-device-unit.rules);
+# seatd (if present) brokers DRM/input access.
+Wants=dev-dri-card0.device
+After=dev-dri-card0.device seatd.service
 
 [Service]
 ExecStart=/usr/bin/home-automation
+# Backstop: if some other early-boot hiccup (e.g. a slightly later display-card
+# probe on the GPU boards, which enumerate two DRM nodes) still trips the first
+# start, retry rather than leaving the screen dark.
+Restart=on-failure
+RestartSec=2
 
 [Install]
 WantedBy=multi-user.target

--- a/dynamic-layers/meta-ti/recipes-example/slint-demos/slint-demos_%.bbappend
+++ b/dynamic-layers/meta-ti/recipes-example/slint-demos/slint-demos_%.bbappend
@@ -4,12 +4,17 @@ SYSTEMD_AUTO_ENABLE = "enable"
 SYSTEMD_SERVICE:${PN} = "slint-demos.service"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
-SRC_URI:append = " file://slint-demos.service"
+SRC_URI:append = " file://slint-demos.service file://99-drm-device-unit.rules"
 FILES:${PN} += "${systemd_unitdir}/system/slint-demos.service"
+FILES:${PN} += "${sysconfdir}/udev/rules.d/99-drm-device-unit.rules"
 
 do_install:append() {
   install -d ${D}/${systemd_unitdir}/system
   install -m 0644 ${UNPACKDIR}/slint-demos.service ${D}/${systemd_unitdir}/system
+  # Tag DRM devices for systemd so dev-dri-card0.device exists for the service
+  # to order after (the display modules probe late; see the unit).
+  install -d ${D}${sysconfdir}/udev/rules.d
+  install -m 0644 ${UNPACKDIR}/99-drm-device-unit.rules ${D}${sysconfdir}/udev/rules.d
 }
 
 # AM62L has no GPU: run the autostarted demo with Skia's software raster. The

--- a/dynamic-layers/meta-ti/recipes-graphics/images/ti-image-slint-demos.bb
+++ b/dynamic-layers/meta-ti/recipes-graphics/images/ti-image-slint-demos.bb
@@ -21,6 +21,16 @@ CORE_IMAGE_BASE_INSTALL += " \
     libnss-mdns \
 "
 
+# DRM/KMS debugging helpers on both boards. These inspect the display path and
+# need no GPU, so they're useful for a dark screen on either board: libdrm-tests
+# (modetest/proptest/modeprint/kmstest) to list the KMS connectors/planes/modes
+# and push a test pattern, and drm-info for a readable dump of every DRM node.
+# Drop this block for a lean production image.
+CORE_IMAGE_BASE_INSTALL += " \
+    libdrm-tests \
+    drm-info \
+"
+
 # The KMS/DRM display path. TI's kernel builds the display-subsystem driver
 # (tidss) and the on-board HDMI bridge (sii902x on the SK boards) as loadable
 # modules, but the machine config doesn't mark them essential -- so a bare
@@ -46,6 +56,17 @@ IMAGE_INSTALL:append:am62pxx-evm = " \
     ti-img-rogue-umlibs \
     mesa-megadriver \
     libegl libgles2 libgbm \
+"
+
+# GLES/GPU smoke tests, AM62Px only -- these exercise the GPU userspace, which
+# only this board ships. mesa-demos (eglinfo/es2_info/es2gears) confirms which
+# EGL/GLES driver is actually loaded (PowerVR vs a software fall-back), and
+# kmscube is a no-compositor GBM/KMS GLES test. AM62L renders in software and has
+# no GLES userspace, so installing these there would only pull mesa onto it for
+# tests that don't reflect its real render path -- leave them off.
+IMAGE_INSTALL:append:am62pxx-evm = " \
+    mesa-demos \
+    kmscube \
 "
 
 # Raw SD-card image; the workflow relabels it to <device>-slint-demo.img and zips

--- a/dynamic-layers/meta-ti/recipes-tisdk/tisdk-uenv/tisdk-uenv.bbappend
+++ b/dynamic-layers/meta-ti/recipes-tisdk/tisdk-uenv/tisdk-uenv.bbappend
@@ -1,0 +1,18 @@
+# AM62L's CMA pool defaults to 32 MB (CONFIG_CMA_SIZE_MBYTES in TI's arm64
+# defconfig; the AM62L devicetree has no linux,cma node), too small for a
+# triple-buffered 2K scanout -- the demo's dumb-buffer allocation then fails.
+# Enlarge it to 64 MB via the kernel command line, without a kernel rebuild:
+# TI's U-Boot imports uEnv.txt (on the FAT boot partition, in IMAGE_BOOT_FILES
+# via arago.conf) after bootcmd and appends ${optargs} to the kernel bootargs,
+# so extend optargs with cma=64M. The arago base uEnv.txt sets no optargs, so
+# U-Boot's default (vt.global_cursor_default=0) applies otherwise -- preserve
+# that and add cma. (A CONFIG_CMA_SIZE_MBYTES fragment would work too but forces
+# a full kernel rebuild; this is a boot-partition-only change.)
+do_deploy:append:am62lxx-evm() {
+    uenv=${DEPLOYDIR}/uEnv.txt
+    if grep -q '^optargs=' "$uenv"; then
+        sed -i '/^optargs=/ s/$/ cma=64M/' "$uenv"
+    else
+        printf '\n# Enlarge CMA for the triple-buffered 2K scanout (Slint demo).\noptargs=vt.global_cursor_default=0 cma=64M\n' >> "$uenv"
+    fi
+}


### PR DESCRIPTION
Add debug tools, fix startup race, and bump cma so that we can allocate frame buffers with large screens.