### PR TITLE
Only apply the pseudo openat2 override on scarthgap

### DIFF
--- a/recipes-devtools/pseudo/pseudo_git.bb
+++ b/recipes-devtools/pseudo/pseudo_git.bb
@@ -1,5 +1,19 @@
 require pseudo.inc
 
+# This recipe only exists to backport the pseudo openat2 fix (pseudo 1.9.8) onto
+# the NXP i.MX scarthgap BSP, which pins pseudo 1.9.0 and breaks do_package on
+# newer host kernels. Every other demo board builds on a newer OpenEmbedded
+# (wrynose), whose own oe-core pseudo already carries that fix -- and there this
+# override is not only redundant but fatal: `S = "${WORKDIR}/git"` below is a
+# hard error on newer bitbake (bitbake.conf sets S itself now). So restrict the
+# override to scarthgap; elsewhere defer to oe-core's pseudo.
+python () {
+    if 'scarthgap' not in (d.getVar('LAYERSERIES_CORENAMES') or '').split():
+        raise bb.parse.SkipRecipe(
+            'pseudo override only needed on the scarthgap i.MX BSP; '
+            'oe-core pseudo already has the openat2 fix on this release')
+}
+
 SRC_URI = "git://git.yoctoproject.org/pseudo;branch=master;protocol=https \
            file://fallback-passwd \
            file://fallback-group \


### PR DESCRIPTION
The vendored pseudo 1.9.8 recipe exists to fix do_package on the NXP i.MX scarthgap BSP, which pins pseudo 1.9.0. It came over from main, where every board is scarthgap. On the dev branch only the i.MX95 build is scarthgap; the TI, Raspberry Pi and STM32 boards build on a newer OpenEmbedded (wrynose), and there the recipe both is redundant (oe-core's own pseudo already carries the openat2 fix) and fails outright -- its `S = "${WORKDIR}/git"` is now a hard error, since bitbake.conf sets S itself. That broke pseudo-native do_unpack and took down the whole build.

Skip the recipe unless scarthgap is in LAYERSERIES_CORENAMES, so it only overrides pseudo on the i.MX BSP that needs it and every wrynose board falls back to oe-core's already-fixed pseudo.