### PR TITLE
Build the Rust recipes with meta-rust-bin's cargo_bin again

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 This layer contains recipes and classes for building Slint's C++ API, as well as the Rust based
 demos.
 
-**Note:** This branch supports wrynose and newer. Support for older versions is located in the `main` branch of this repository.
-
-For a Rust based application using Slint, rely on OE-core's built-in Rust and `cargo` class support directly.
+For a Rust based application using Slint, use [meta-rust-bin](https://github.com/rust-embedded/meta-rust-bin) directly.
 
 For a C++ based application, the recipes in this layer assume that your application is built using CMake and
 uses `find_package(Slint)` to locate Slint, and then uses `slint_target_sources` to compile `.slint` files to C++
@@ -18,11 +16,12 @@ Meta-slint requires:
 
 ```
 meta-openembedded/meta-oe
+meta-rust-bin
 ```
 
-The `dev` branch targets Yocto master (`wrynose`); the `main` branch tracks the previous stable
-release. Check the [layer.conf](conf/layer.conf) `LAYERSERIES_COMPAT_meta-slint` for yocto version
-compatibility.
+The layer supports kirkstone through wrynose. Check the
+[layer.conf](conf/layer.conf) `LAYERSERIES_COMPAT_meta-slint` for the exact list of supported
+Yocto releases.
 
 By default, yocto will pick the `_git` recipe of `slint-cpp`, which means the development version
 of Slint will be built. To select a specific Slint version, in your `conf/local.conf`, set
@@ -94,6 +93,7 @@ environment enables an additional `fus-image-slint-demos` image target.
 
 Steps:
   - Add [meta-clang](https://github.com/kraj/meta-clang)
+  - Add [meta-rust-bin](https://github.com/rust-embedded/meta-rust-bin)
   - Add `meta-slint`
   - Edit your `conf/local.conf`:
     - Make sure `DISTRO` is set to `"fus-imx-wayland"`
@@ -106,6 +106,7 @@ adding this `meta-slint` layer to your environment enables an additional `core-i
 
 Steps:
   - Add [meta-clang](https://github.com/kraj/meta-clang)
+  - Add [meta-rust-bin](https://github.com/rust-embedded/meta-rust-bin)
   - Add `meta-slint`
   - Run `bitbake core-image-slint-demos` to build an image that ships various Slint demos in a minimal image. The demos run directly on the framebuffer with the LinuxKMS backend.
 
@@ -116,6 +117,7 @@ adding this `meta-slint` layer to your enrivonment enables an additional `imx-im
 
 Steps:
   - Add [meta-clang](https://github.com/kraj/meta-clang)
+  - Add [meta-rust-bin](https://github.com/rust-embedded/meta-rust-bin)
   - Add `meta-slint`
   - Run `bitbake imx-image-slint-demos` to build an image that ships various Slint demos in a minimal image. The demos run directly on the framebuffer with the LinuxKMS backend.
 

--- a/classes/slint_common.bbclass
+++ b/classes/slint_common.bbclass
@@ -1,16 +1,22 @@
 TARGET_CFLAGS:remove = "-fcanon-prefix-map"
 
+# scarthgap needs S at the git checkout; newer OE (whinlatter/wrynose) sets it
+# itself and hard-errors on the explicit assignment, so only set it on scarthgap.
+# Every slint_common consumer is a git-checkout recipe.
+python () {
+    if 'scarthgap' in (d.getVar('LAYERSERIES_CORENAMES') or '').split():
+        d.setVar('S', '${WORKDIR}/git')
+}
+
 # The Skia renderer builds Skia from source with GN + ninja (skia-bindings), and
 # not every BSP provides ninja-native (OpenSTLinux doesn't), so depend on it.
 DEPENDS:append:class-target = " ninja-native"
 
-# skia-bindings also runs bindgen, which dlopens libclang.so to generate the Rust
-# bindings for Skia's headers. Provide the native libclang and point bindgen at
-# it via LIBCLANG_PATH; the target headers are still parsed cross, through the
-# --target/--sysroot in BINDGEN_EXTRA_CLANG_ARGS below. (meta-rust-bin used to
-# make this discoverable; oe-core's cargo does not.)
-DEPENDS:append:class-target = " clang-native"
-export LIBCLANG_PATH = "${STAGING_LIBDIR_NATIVE}"
+# oe-core's rust classes remap ${WORKDIR} out of the debug paths rustc bakes in
+# (rust-common's RUST_DEBUG_REMAP); meta-rust-bin's cargo_bin does not, so the
+# absolute ${WORKDIR}/sources/cargo_home crate paths end up in the binaries and
+# trip the buildpaths QA check. Apply the same remap rustc-side.
+RUSTFLAGS += "--remap-path-prefix=${WORKDIR}=${TARGET_DBGSRC_DIR}"
 
 do_compile:prepend() {
     #export RUSTFLAGS="${RUSTFLAGS}"
@@ -19,24 +25,6 @@ do_compile:prepend() {
     # passes the right flags, in particular float abi selection
     export BINDGEN_EXTRA_CLANG_ARGS="${HOST_CC_ARCH} ${TOOLCHAIN_OPTIONS} ${TARGET_CFLAGS}"
 }
-
-# The skia-bindings crate compiles its src/bindings.cpp with the cargo cc-crate
-# wrapper, which embeds oe-core's DEBUG_PREFIX_MAP. That map only remaps ${S}, ${B}
-# and the sysroots — NOT ${WORKDIR}/sources/cargo_home, where the skia-bindings crate
-# and the bundled Skia headers live. So absolute __FILE__ paths (e.g. the bundled
-# .../skia/include/codec/SkEncodedOrigin.h) get baked into libslint_cpp.so's .rodata
-# and trip the buildpaths QA check. Extend the map to cover the whole ${WORKDIR} so
-# those cargo_home paths are remapped too. (Skia's own gn/ninja compile already emits
-# relative paths, so it isn't affected.)
-DEBUG_PREFIX_MAP:append:class-target = " -ffile-prefix-map=${WORKDIR}=/usr/src/debug/${PN}/${PV}"
-
-# The -src package (poky default PACKAGE_DEBUG_SPLIT_STYLE=debug-with-srcpkg) ships
-# debug sources, including build-script-generated files. The `built` crate used by
-# rav1e (pulled in via Skia's AVIF image support) writes a built.rs recording absolute
-# build paths (e.g. the rustc path) as string literals — these are not in any binary
-# (dead code, absent from libslint_cpp.so) but trip buildpaths QA on the source package.
-# Skip buildpaths for the -src package only; the binary packages keep full QA.
-INSANE_SKIP:${PN}-src += "buildpaths"
 
 # Emulate what clang-environment.inc does.
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,8 +9,12 @@ BBFILE_COLLECTIONS += "meta-slint"
 BBFILE_PATTERN_meta-slint = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-slint = "6"
 
-LAYERDEPENDS_meta-slint = "core"
-LAYERSERIES_COMPAT_meta-slint = "wrynose"
+LAYERDEPENDS_meta-slint = "core rust-bin-layer"
+LAYERSERIES_COMPAT_meta-slint = "kirkstone langdale mickledore nanbield scarthgap styhead walnascar whinlatter wrynose"
+
+# The Rust recipes build via meta-rust-bin's cargo_bin class, which needs the
+# panic strategy set for the target Rust std it ships.
+RUST_PANIC_STRATEGY = "abort"
 
 BBFILES_DYNAMIC += " \
     st-openstlinux:${LAYERDIR}/dynamic-layers/meta-st-openstlinux/*/*/*.bb \

--- a/recipes-example/slint-demos/slint-demos_1.17.1.bb
+++ b/recipes-example/slint-demos/slint-demos_1.17.1.bb
@@ -1,4 +1,4 @@
-inherit cargo
+inherit cargo_bin
 inherit pkgconfig
 
 # Pinned to a release (not master): the demos get reshuffled on master, e.g. the
@@ -29,17 +29,13 @@ DEPENDS:append:class-target = " \
 RDEPENDS:${PN}:class-target += "xkeyboard-config"
 
 CARGO_DISABLE_BITBAKE_VENDORING = "1"
-CARGO_BUILD_FLAGS = "-v --target ${RUST_HOST_SYS} ${BUILD_MODE} --manifest-path=${CARGO_MANIFEST_PATH}"
-
-# cargo.bbclass passes features only via PACKAGECONFIG_CONFARGS (empty here);
-# So append --features explicitly so machine-specific CARGO_FEATURES overrides take effect.
-CARGO_BUILD_FLAGS:append = " ${@'--features ' + ','.join(d.getVar('CARGO_FEATURES').split()) if d.getVar('CARGO_FEATURES') else ''}"
 
 # Build only the demo binaries. A bare `cargo build` compiles the whole default
 # workspace -- including slint-viewer (which has its own recipe) and other tools
 # -- which is slow and made slint-demos ship /usr/bin/slint-viewer, clashing with
 # the slint-viewer package at rootfs time. Scope the build with one -p per demo.
-CARGO_BUILD_FLAGS:append = " ${@' '.join('-p ' + p for p in (d.getVar('SLINT_DEMOS') or '').split())}"
+# cargo_bin turns CARGO_FEATURES into --features on its own.
+EXTRA_CARGO_FLAGS = "${@' '.join('-p ' + p for p in (d.getVar('SLINT_DEMOS') or '').split())}"
 
 do_configure[network] = "1"
 do_compile[network] = "1"
@@ -54,18 +50,22 @@ SLINT_DEMOS = "slide_puzzle printerdemo gallery opengl_texture opengl_underlay e
 do_compile:prepend() {
     CURL_CA_BUNDLE=${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt
     export CURL_CA_BUNDLE
-    # Use the git protocol for the crates.io index instead of sparse HTTP
-    # so cargo doesn't open hundreds of HTTP/1.1 connections at once
-    # (OE-core's curl-native is built without HTTP/2 -- see commit message).
-    export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git
-    export CARGO_HTTP_TIMEOUT=120
-    export CARGO_NET_RETRY=5
     # Skia + LTO is very RAM-hungry; keep LTO off.
     export CARGO_PROFILE_RELEASE_LTO=false
 }
 do_compile:append() {
-    rm -f "${B}/target/${CARGO_TARGET_SUBDIR}"/*.so
-    rm -f "${B}/target/${CARGO_TARGET_SUBDIR}"/*.rlib
+    # cargo_bin_do_install ships every .so/.rlib next to the demo binaries; drop
+    # them so the demos package carries just the executables.
+    rm -f "${CARGO_BINDIR}"/*.so
+    rm -f "${CARGO_BINDIR}"/*.rlib
 }
 
+# The demo binaries carry absolute build paths that the Rust --remap-path-prefix
+# cannot rewrite: the slint compiler bakes the gettext translation dir
+# (examples/*/lang) in as a string literal, and the vendored aws-lc-sys C crate
+# bakes its source paths into debug info. These are example binaries, so accept
+# the paths rather than chase every embedder. (slint-cpp/viewer/launcher are fully
+# remapped and keep the check.)
 INSANE_SKIP:${PN} += "buildpaths"
+INSANE_SKIP:${PN}-dbg += "buildpaths"
+INSANE_SKIP:${PN}-src += "buildpaths"

--- a/recipes-example/slint-hello-rust/slint-hello-world-rust_git.bb
+++ b/recipes-example/slint-hello-rust/slint-hello-world-rust_git.bb
@@ -1,4 +1,4 @@
-inherit cargo
+inherit cargo_bin
 
 SRC_URI = "git://github.com/slint-ui/slint-rust-template.git;protocol=https;branch=main;rev=main"
 
@@ -8,6 +8,18 @@ LICENSE = "GPL-3.0-only | Slint-Commercial"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=9e911597e678943cde54111f7518e299"
 
 DEPENDS:append = " fontconfig"
+
+# meta-rust-bin's cargo_bin doesn't remap ${WORKDIR} out of rustc's baked-in
+# debug paths the way oe-core's rust classes do, so do it here to keep the
+# absolute cargo_home paths out of the binary (buildpaths QA).
+RUSTFLAGS += "--remap-path-prefix=${WORKDIR}=${TARGET_DBGSRC_DIR}"
+
+# scarthgap needs S at the git checkout; newer OE (whinlatter/wrynose) sets it
+# itself and rejects the explicit assignment, so only set it on scarthgap.
+python () {
+    if 'scarthgap' in (d.getVar('LAYERSERIES_CORENAMES') or '').split():
+        d.setVar('S', '${WORKDIR}/git')
+}
 
 PV = "slint-hello-world-rust-${SRCPV}"
 

--- a/recipes-example/slint-hello-world/slint-hello-world_git.bb
+++ b/recipes-example/slint-hello-world/slint-hello-world_git.bb
@@ -8,6 +8,13 @@ HOMEPAGE = "https://github.com/slint-ui/slint"
 LICENSE = "GPL-3.0-only | Slint-Commercial"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=9e911597e678943cde54111f7518e299"
 
+# scarthgap needs S at the git checkout; newer OE (whinlatter/wrynose) sets it
+# itself and rejects the explicit assignment, so only set it on scarthgap.
+python () {
+    if 'scarthgap' in (d.getVar('LAYERSERIES_CORENAMES') or '').split():
+        d.setVar('S', '${WORKDIR}/git')
+}
+
 PV = "slint-hello-world-${SRCPV}"
 
 do_install() {

--- a/recipes-example/slint-launcher/slint-launcher_git.bb
+++ b/recipes-example/slint-launcher/slint-launcher_git.bb
@@ -1,4 +1,4 @@
-inherit cargo
+inherit cargo_bin
 inherit pkgconfig
 
 # The launcher (demos/launcher) only exists on master; it is not in the release
@@ -46,12 +46,9 @@ CARGO_DISABLE_BITBAKE_VENDORING = "1"
 # enabling that feature makes Skia the default renderer, so no runtime override
 # is needed.
 CARGO_MANIFEST_PATH = "${S}/demos/Cargo.toml"
-CARGO_BUILD_FLAGS = "-v --target ${RUST_HOST_SYS} ${BUILD_MODE} --manifest-path=${CARGO_MANIFEST_PATH} --no-default-features -p launcher"
 
-# cargo.bbclass passes features only via PACKAGECONFIG_CONFARGS (empty here);
-# So append --features explicitly so machine-specific CARGO_FEATURES overrides take effect.
-CARGO_BUILD_FLAGS:append = " ${@'--features ' + ','.join(d.getVar('CARGO_FEATURES').split()) if d.getVar('CARGO_FEATURES') else ''}"
-
+# cargo_bin turns CARGO_FEATURES into --features on its own.
+EXTRA_CARGO_FLAGS = "--no-default-features -p launcher"
 CARGO_FEATURES = "backend-linuxkms renderer-skia"
 
 do_configure[network] = "1"
@@ -60,21 +57,15 @@ do_compile[network] = "1"
 do_compile:prepend() {
     CURL_CA_BUNDLE=${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt
     export CURL_CA_BUNDLE
-    # Use the git protocol for the crates.io index instead of sparse HTTP
-    # so cargo doesn't open hundreds of HTTP/1.1 connections at once
-    # (OE-core's curl-native is built without HTTP/2).
-    export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git
-    export CARGO_HTTP_TIMEOUT=120
-    export CARGO_NET_RETRY=5
     # Skia + LTO is very RAM-hungry; keep LTO off (as slint-demos does).
     export CARGO_PROFILE_RELEASE_LTO=false
 }
 do_compile:append() {
-    rm -f "${B}/target/${CARGO_TARGET_SUBDIR}"/*.so
-    rm -f "${B}/target/${CARGO_TARGET_SUBDIR}"/*.rlib
+    # cargo_bin_do_install ships every .so/.rlib next to the launcher binary; drop
+    # them so the package carries just the executable.
+    rm -f "${CARGO_BINDIR}"/*.so
+    rm -f "${CARGO_BINDIR}"/*.rlib
 }
-
-INSANE_SKIP:${PN} += "buildpaths"
 
 # The launcher is the boot entry point: autostart it, and it launches the demos.
 inherit systemd
@@ -85,5 +76,7 @@ FILES:${PN} += "${systemd_unitdir}/system/slint-launcher.service"
 
 do_install:append() {
     install -d ${D}${systemd_unitdir}/system
-    install -m 0644 ${WORKDIR}/slint-launcher.service ${D}${systemd_unitdir}/system
+    # COMPATIBLE_PACKDIR (from cargo_bin) is where file:// SRC_URI entries land:
+    # UNPACKDIR on walnascar+ (whinlatter/wrynose), WORKDIR on scarthgap.
+    install -m 0644 ${COMPATIBLE_PACKDIR}/slint-launcher.service ${D}${systemd_unitdir}/system
 }

--- a/recipes-slint/slint-viewer/slint-viewer_1.17.1.bb
+++ b/recipes-slint/slint-viewer/slint-viewer_1.17.1.bb
@@ -1,4 +1,4 @@
-inherit cargo
+inherit cargo_bin
 inherit pkgconfig
 inherit slint_common
 inherit features_check
@@ -35,31 +35,20 @@ RDEPENDS:${PN}:class-target += "xkeyboard-config"
 
 # Fetch crate dependencies straight from crates.io rather than pre-vendoring.
 CARGO_DISABLE_BITBAKE_VENDORING = "1"
-CARGO_BUILD_FLAGS = "-v --target ${RUST_HOST_SYS} ${BUILD_MODE} --manifest-path=${CARGO_MANIFEST_PATH} -p slint-viewer --bin slint-viewer"
 
-# cargo.bbclass passes features only via PACKAGECONFIG_CONFARGS (empty here);
-# So append --features explicitly so machine-specific CARGO_FEATURES overrides take effect.
-CARGO_BUILD_FLAGS:append = " ${@'--features ' + ','.join(d.getVar('CARGO_FEATURES').split()) if d.getVar('CARGO_FEATURES') else ''}"
+# Build just the viewer binary (its cdylib lib target is Android-only). cargo_bin
+# turns CARGO_FEATURES into --features on its own.
+EXTRA_CARGO_FLAGS = "-p slint-viewer --bin slint-viewer"
+CARGO_FEATURES = "remote backend-linuxkms renderer-skia"
 
 do_configure[network] = "1"
 do_compile[network] = "1"
-
-CARGO_FEATURES = "remote backend-linuxkms renderer-skia"
 
 do_compile:prepend() {
     CURL_CA_BUNDLE=${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt
     export CURL_CA_BUNDLE
 
-    # Use the git protocol for the crates.io index instead of sparse HTTP
-    # so cargo doesn't open hundreds of HTTP/1.1 connections at once
-    # (OE-core's curl-native is built without HTTP/2).
-    export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git
-    export CARGO_HTTP_TIMEOUT=120
-    export CARGO_NET_RETRY=5
-
     # Skia + LTO is very RAM-hungry; keep LTO off (as slint-demos does). The job
     # count is bounded globally via CARGO_BUILD_JOBS (see common.sh).
     export CARGO_PROFILE_RELEASE_LTO=false
 }
-
-INSANE_SKIP:${PN} += "buildpaths"

--- a/recipes-slint/slint/slint-cpp-v2.inc
+++ b/recipes-slint/slint/slint-cpp-v2.inc
@@ -1,4 +1,4 @@
-inherit cargo
+inherit cargo_bin
 
 SUMMARY = "Slint C++ UI Toolkit"
 DESCRIPTION = "Slint is a toolkit to efficiently develop fluid graphical \
@@ -50,7 +50,6 @@ PACKAGECONFIG[experimental] = "-DSLINT_FEATURE_EXPERIMENTAL=ON, -DSLINT_FEATURE_
 PACKAGECONFIG[system-testing] = "-DSLINT_FEATURE_SYSTEM_TESTING=ON, -DSLINT_FEATURE_SYSTEM_TESTING=OFF,"
 
 CARGO_DISABLE_BITBAKE_VENDORING = "1"
-CARGO_BUILD_FLAGS = "-v --target ${RUST_HOST_SYS} ${BUILD_MODE} --manifest-path=${CARGO_MANIFEST_PATH}"
 
 # For FetchContent of corrosion
 do_configure[network] = "1"
@@ -60,24 +59,24 @@ do_compile[network] = "1"
 do_configure:prepend:class-nativesdk() {
     # Since Corrosion decides that the native build is not a cross-build, it won't forward CMAKE_SYSROOT.
     # The sysroot however is instrumental, so pass it along via the toolchain and the cargo compile wrappers.
-    echo "set(CMAKE_C_COMPILER \"${RUST_TARGET_CC}\")" >> ${WORKDIR}/toolchain.cmake
-    echo "set(CMAKE_CXX_COMPILER \"${RUST_TARGET_CXX}\")" >> ${WORKDIR}/toolchain.cmake
+    echo "set(CMAKE_C_COMPILER \"${WRAPPER_DIR}/cc-wrapper.sh\")" >> ${WORKDIR}/toolchain.cmake
+    echo "set(CMAKE_CXX_COMPILER \"${WRAPPER_DIR}/cxx-wrapper.sh\")" >> ${WORKDIR}/toolchain.cmake
 }
 
 do_configure() {
     echo "set(CMAKE_SYSROOT \"${RECIPE_SYSROOT}\")" >> ${WORKDIR}/toolchain.cmake
-    cargo_common_do_configure
+    cargo_bin_do_configure
     cmake_do_configure
 }
 
 do_compile:prepend() {
-    oe_cargo_fix_env
-    export TARGET_CC="${RUST_TARGET_CC}"
-    export TARGET_CXX="${RUST_TARGET_CXX}"
-    export CC="${RUST_BUILD_CC}"
-    export CXX="${RUST_BUILD_CXX}"
-    export TARGET_LD="${RUST_TARGET_CCLD}"
-    export LD="${RUST_BUILD_CCLD}"
+    # Wrappers created by cargo_bin_do_configure
+    export TARGET_CC="${WRAPPER_DIR}/cc-wrapper.sh"
+    export TARGET_CXX="${WRAPPER_DIR}/cxx-wrapper.sh"
+    export CC="${WRAPPER_DIR}/cc-native-wrapper.sh"
+    export CXX="${WRAPPER_DIR}/cxx-native-wrapper.sh"
+    export TARGET_LD="${WRAPPER_DIR}/linker-wrapper.sh"
+    export LD="${WRAPPER_DIR}/linker-native-wrapper.sh"
     export PKG_CONFIG_ALLOW_CROSS="1"
     export LDFLAGS=""
     export RUSTFLAGS="${RUSTFLAGS}"
@@ -90,8 +89,8 @@ do_compile:prepend() {
     export CARGO_UNSTABLE_TARGET_APPLIES_TO_HOST="true"
     export CARGO_UNSTABLE_HOST_CONFIG="true"
     export CARGO_TARGET_APPLIES_TO_HOST="false"
-    export CARGO_TARGET_${@d.getVar('RUST_HOST_SYS').replace('-','_').upper()}_LINKER="${RUST_TARGET_CCLD}"
-    export CARGO_HOST_LINKER="${RUST_BUILD_CCLD}"
+    export CARGO_TARGET_${@rust_target(d, 'TARGET').replace('-','_').upper()}_LINKER="${WRAPPER_DIR}/linker-wrapper.sh"
+    export CARGO_HOST_LINKER="${WRAPPER_DIR}/linker-native-wrapper.sh"
     export CARGO_BUILD_FLAGS="-C rpath"
     export CARGO_PROFILE_RELEASE_DEBUG="true"
 
@@ -123,7 +122,7 @@ FILES:${PN} += "/usr/lib/libslint_cpp.so"
 #OECMAKE_C_COMPILER = "${RUST_TARGET_CC}"
 #OECMAKE_CXX_COMPILER = "${RUST_TARGET_CXX}"
 
-EXTRA_OECMAKE:append = " -DRust_CARGO_TARGET=${RUST_HOST_SYS}"
+EXTRA_OECMAKE:append = " -DRust_CARGO_TARGET=${RUST_TARGET}"
 
 EXTRA_OECMAKE:append = " -DFETCHCONTENT_FULLY_DISCONNECTED=OFF"
 EXTRA_OECMAKE:append = " -DBUILD_TESTING=OFF -DSLINT_BUILD_EXAMPLES=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo"

--- a/scripts/ci_setup.sh
+++ b/scripts/ci_setup.sh
@@ -12,13 +12,15 @@ git clone -b master https://git.openembedded.org/bitbake
 
 # bitbake-setup lands the build under bitbake-builds/poky-master/ (a
 # bitbake-builds "top dir" wrapper plus the setup-dir-name from the
-# registry config). Drop our two extra layers alongside the ones it cloned.
+# registry config). Drop our extra layers alongside the ones it cloned.
 git clone -b master https://github.com/kraj/meta-clang.git bitbake-builds/poky-master/layers/meta-clang
+git clone -b master https://github.com/rust-embedded/meta-rust-bin.git bitbake-builds/poky-master/layers/meta-rust-bin
 ln -s "$(cd "$(dirname "$0")/.." && pwd)" bitbake-builds/poky-master/layers/meta-slint
 
 cd bitbake-builds/poky-master
 . build/init-build-env
 bitbake-layers add-layer ../layers/meta-clang
+bitbake-layers add-layer ../layers/meta-rust-bin
 bitbake-layers add-layer ../layers/meta-slint
 
 echo 'PREFERRED_PROVIDER_virtual/kernel = "linux-dummy"' >> conf/local.conf


### PR DESCRIPTION
The dev branch had ported to OE-core's cargo class only because meta-rust-bin lacked wrynose support. That support has since landed, so move back to cargo_bin -- the class the rest of the layer already targets -- and drop the compensations the OE-core port required.

Unlike OE-core's rust classes, cargo_bin does not remap build paths out of the binaries, so add that explicitly to keep the buildpaths QA happy.

Keep the layer building on scarthgap alongside wrynose, since the vendor-BSP boards are still pinned to scarthgap.