### PR TITLE
Add meta-rust-bin to the TI build

### DIFF
--- a/scripts/demo-images/ti-common.sh
+++ b/scripts/demo-images/ti-common.sh
@@ -54,13 +54,20 @@ slint_demo_build_ti() {
         echo "::error::TI oe-layersetup did not set up the build environment (bitbake not on PATH)"; exit 1
     fi
 
-    # Add meta-clang and meta-slint on top of the TI layers. meta-slint on this
-    # (wrynose) branch builds Rust via oe-core's cargo, so no meta-rust-bin.
+    # Add meta-clang, meta-rust-bin and meta-slint on top of the TI layers.
     local layers="$setup/sources"
     local meta_clang_dir="$layers/meta-clang"
     if ! bitbake-layers show-layers 2>/dev/null | grep -Fq "/meta-clang"; then
         [ -d "$meta_clang_dir" ] || git clone -b "$meta_clang_branch" https://github.com/kraj/meta-clang.git "$meta_clang_dir"
         bitbake-layers add-layer "$meta_clang_dir"
+    fi
+    # meta-slint builds its Rust recipes with meta-rust-bin's cargo_bin class, so
+    # it LAYERDEPENDS on rust-bin-layer -- add meta-rust-bin before meta-slint.
+    # (meta-rust-bin tracks master; no per-release branches.)
+    local meta_rust_bin_dir="$layers/meta-rust-bin"
+    if ! bitbake-layers show-layers 2>/dev/null | grep -Fq "/meta-rust-bin"; then
+        [ -d "$meta_rust_bin_dir" ] || git clone https://github.com/rust-embedded/meta-rust-bin.git "$meta_rust_bin_dir"
+        bitbake-layers add-layer "$meta_rust_bin_dir"
     fi
     slint_demo_add_layer_if_missing "$meta_slint_dir"
 


### PR DESCRIPTION
The TI build script added meta-clang and meta-slint but not meta-rust-bin, on the assumption that the demos build via oe-core's cargo. That's no longer true: meta-slint's Rust recipes now use meta-rust-bin's cargo_bin class, so meta-slint LAYERDEPENDS on rust-bin-layer. Without the layer the build fails immediately at layer setup:

  ERROR: Layer 'meta-slint' depends on layer 'rust-bin-layer', but this layer
  is not enabled in your configuration

Clone and add meta-rust-bin (master, like the other boards) before meta-slint so the dependency is satisfied.