### PR TITLE
CI: test against the latest Yocto release instead of master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: "ci setup"
         run: |
           su - build -c "cd ${{ runner.workspace }}/meta-slint && meta-slint/scripts/ci_setup.sh"
-      - name: "test master"
+      - name: "test latest release"
         run: |
           su - build -c "cd ${{ runner.workspace }}/meta-slint && meta-slint/scripts/ci.sh"
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -2,14 +2,13 @@
 
 set -ex
 
-cd bitbake-builds/poky-master
+cd bitbake-builds/poky-wrynose
 . build/init-build-env
 bitbake-layers show-layers
 bitbake -c compile slint-hello-world
 bitbake -c compile slint-demos
-# Disabled: populate_sdk pushes the total run time past GitHub Actions'
-# 6h job timeout on the Hetzner cx53 runner. The hello-world + demos
-# compiles together already exercise slint-cpp and the cargo plumbing;
-# re-enable once we've sped things up (bigger runner, less conservative
+# Disabled: populate_sdk pushes the total run time past GitHub Actions' 6h job
+# timeout. The hello-world + demos compiles together already exercise slint-cpp
+# and the cargo plumbing; re-enable once we've sped things up (less conservative
 # BB_NUMBER_THREADS / CARGO_BUILD_JOBS, or a higher timeout-minutes).
 #bitbake core-image-minimal -c populate_sdk

--- a/scripts/ci_setup.sh
+++ b/scripts/ci_setup.sh
@@ -1,24 +1,29 @@
 #!/bin/bash
 set -ex
 
-# poky's master branch is just a README now; use bitbake-setup from bitbake
-# itself. Clone only bitbake to bootstrap it.
+# Test against the latest Yocto release (wrynose, 6.0), not master. Master is a
+# moving target -- e.g. meta-rust-bin's rust-bin prebuilt handling currently
+# breaks there -- and isn't what we ship. poky's git has no release branches
+# (its master is just a README), so use bitbake-setup: its poky-wrynose config
+# assembles the release from openembedded-core@wrynose + meta-yocto@wrynose and
+# pins bitbake. Clone bitbake only to bootstrap the tool.
 git clone -b master https://git.openembedded.org/bitbake
 
-# The poky-with-sstate configuration bundles the sstate CDN mirror fragment,
-# so we inherit BB_HASHSERVE_UPSTREAM + SSTATE_MIRRORS automatically.
+# poky-with-sstate bundles the sstate CDN mirror fragment, so we inherit
+# BB_HASHSERVE_UPSTREAM + SSTATE_MIRRORS automatically.
 ./bitbake/bin/bitbake-setup init --non-interactive \
-    poky-master poky-with-sstate distro/poky machine/qemuarm64
+    poky-wrynose poky-with-sstate distro/poky machine/qemuarm64
 
-# bitbake-setup lands the build under bitbake-builds/poky-master/ (a
-# bitbake-builds "top dir" wrapper plus the setup-dir-name from the
-# registry config). Drop our extra layers alongside the ones it cloned.
-git clone -b master https://github.com/kraj/meta-clang.git bitbake-builds/poky-master/layers/meta-clang
-git clone -b master https://github.com/rust-embedded/meta-rust-bin.git bitbake-builds/poky-master/layers/meta-rust-bin
-ln -s "$(cd "$(dirname "$0")/.." && pwd)" bitbake-builds/poky-master/layers/meta-slint
+# bitbake-setup lands the build under bitbake-builds/poky-wrynose/ (setup-dir-name
+# "$distro-wrynose" with distro/poky). Drop our extra layers alongside the ones it
+# cloned: meta-clang at the release, meta-rust-bin at master (no release branch).
+git clone -b wrynose https://github.com/kraj/meta-clang.git bitbake-builds/poky-wrynose/layers/meta-clang
+git clone https://github.com/rust-embedded/meta-rust-bin.git bitbake-builds/poky-wrynose/layers/meta-rust-bin
+ln -s "$(cd "$(dirname "$0")/.." && pwd)" bitbake-builds/poky-wrynose/layers/meta-slint
 
-cd bitbake-builds/poky-master
+cd bitbake-builds/poky-wrynose
 . build/init-build-env
+# meta-rust-bin (rust-bin-layer) before meta-slint, which LAYERDEPENDS on it.
 bitbake-layers add-layer ../layers/meta-clang
 bitbake-layers add-layer ../layers/meta-rust-bin
 bitbake-layers add-layer ../layers/meta-slint
@@ -28,9 +33,9 @@ echo 'CLANGSDK = "1"' >> conf/local.conf
 echo 'PACKAGECONFIG:append:pn-slint-cpp = " backend-linuxkms renderer-skia system-testing"' >> conf/local.conf
 echo 'TOOLCHAIN_HOST_TASK:append = " nativesdk-slint-cpp"' >> conf/local.conf
 echo 'INHERIT:remove = "create-spdx"' >> conf/local.conf
-# Cap parallelism: Hetzner cx53 has 32G RAM but rustc + LTO linking the
-# slint crate graph can spike multiple GB per job. Build-time wins from
-# parallelism don't help if a single oversubscribed task OOMs the box.
+# Cap parallelism: the runner has 32G RAM but rustc + LTO linking the slint
+# crate graph can spike multiple GB per job, so an oversubscribed task can OOM
+# the box. Build-time wins from parallelism don't help if a single task OOMs.
 echo 'BB_NUMBER_THREADS = "4"' >> conf/local.conf
 echo 'PARALLEL_MAKE = "-j 4"' >> conf/local.conf
 echo 'export CARGO_BUILD_JOBS = "2"' >> conf/local.conf


### PR DESCRIPTION
The CI built against poky master via bitbake-setup, which is both a moving target and not what we ship -- it just broke on meta-rust-bin's rust-bin-cross do_install (the prebuilt's install.sh is absent on master), while the same meta-rust-bin builds fine on the release the demo images use.

Point bitbake-setup at its poky-wrynose config instead of poky-master. poky's git has no release branches (its master is just a README), but bitbake-setup's poky-wrynose assembles the 6.0 release from openembedded-core@wrynose + meta-yocto@wrynose and pins bitbake -- so a plain `git clone -b wrynose poky` would fail, but this works. Keep poky-with-sstate for the upstream sstate CDN, clone meta-clang at the release (meta-rust-bin has no release branch, stays master), and land everything under bitbake-builds/poky-wrynose. Test targets (slint-hello-world / slint-demos compile) are unchanged.